### PR TITLE
Add gemini as a judge LLM option.

### DIFF
--- a/eval_config.yaml
+++ b/eval_config.yaml
@@ -9,7 +9,7 @@ evaluation_results: "open_eval_results.csv"
 evaluator:
   type: "TRECEvaluator"  
   model:
-    type: "openai"
+    type: "OpenAIModel"
     name: "gpt-4o-mini"
     api_key: ${oc.env:OPENAI_API_KEY}  # Reads from environment variable.
 

--- a/open_rag_eval/metrics/autonugget_metric.py
+++ b/open_rag_eval/metrics/autonugget_metric.py
@@ -148,8 +148,8 @@ class AutoNuggetMetric(AugmentedGenerationMetric):
                 logging.error(f"Failed to create nuggets: {e}")
                 raise e
 
-            if response.parsed:
-                nuggets = response.parsed.nuggets
+            if response.nuggets:
+                nuggets = response.nuggets
             else:
                 logging.error(f"Failed to parse nuggets from response: {response.refusal} for query {query}.")
                 raise ValueError(f"Failed to parse nuggets from response: {response.refusal} for query {query}.")
@@ -182,8 +182,8 @@ class AutoNuggetMetric(AugmentedGenerationMetric):
                 logging.error(f"Failed to create nuggets: {e}")
                 raise e
 
-            if response.parsed:
-                labels.extend(response.parsed.importance)
+            if response.importance:
+                labels.extend(response.importance)
             else:
                 logging.error(f"Failed to score nuggets from response: {response.refusal} for query {query}.")
                 raise ValueError(f"Failed to score nuggets from response: {response.refusal} for query {query}.")
@@ -220,8 +220,8 @@ class AutoNuggetMetric(AugmentedGenerationMetric):
             except Exception as e:
                 logging.error(f"Failed to create nuggets: {e}")
                 raise e
-            if response.parsed:
-                assignments.extend(response.parsed.assignment)
+            if response.assignment:
+                assignments.extend(response.assignment)
             else:
                 logging.error(f"Failed to assign nuggets from response: {response.refusal} for query {query}.")
                 raise ValueError(f"Failed to assign nuggets from response: {response.refusal} for query {query}.")

--- a/open_rag_eval/metrics/citation_metric.py
+++ b/open_rag_eval/metrics/citation_metric.py
@@ -85,10 +85,10 @@ class CitationMetric(AugmentedGenerationMetric):
                     citation=passage
                 )
                 response = self.model.parse(prompt, response_format=CitationSupport)
-                if not response.parsed:
+                if not response.support:
                     raise ValueError(f"Failed to parse response: {response.refusal}")
 
-                label = response.parsed.support.value
+                label = response.support.value
                 scores[f"citation_score_{key}"] = self.score_map[label]
             except Exception as e:
                 raise Exception(f"Error computing Citation score: {str(e)}") from e

--- a/open_rag_eval/metrics/umbrela_metric.py
+++ b/open_rag_eval/metrics/umbrela_metric.py
@@ -83,10 +83,10 @@ class UMBRELAMetric(RetrievalMetric):
                 prompt = self.prompt.format(query=query, passage=passage)
                 response = self.model.parse(prompt, response_format=UMBRELAScore)
 
-                if not response.parsed:
+                if not response.score:
                     raise ValueError(f"Failed to parse response: {response.refusal}")
 
-                scores[key] = score_map[response.parsed.score.value]
+                scores[key] = score_map[response.score.value]
 
             except Exception as e:
                 raise Exception(f"Error computing UMBRELA score: {str(e)}") from e

--- a/open_rag_eval/models/__init__.py
+++ b/open_rag_eval/models/__init__.py
@@ -1,3 +1,3 @@
-from .llm_judges import LLMJudgeModel, OpenAIModel
+from .llm_judges import LLMJudgeModel, OpenAIModel, GeminiModel
 
-__all__ = ["LLMJudgeModel", "OpenAIModel"]
+__all__ = ["LLMJudgeModel", "OpenAIModel", "GeminiModel"]

--- a/open_rag_eval/models/llm_judges.py
+++ b/open_rag_eval/models/llm_judges.py
@@ -1,7 +1,11 @@
-from abc import ABC
-from pydantic import BaseModel
-
+import json
 import openai
+
+from abc import ABC
+from google import genai
+from pydantic import BaseModel
+from pydantic.tools import parse_obj_as
+
 
 class LLMJudgeModel(ABC):
     """Abstract base class for LLM judge models."""
@@ -9,7 +13,7 @@ class LLMJudgeModel(ABC):
 
 
 class OpenAIModel(LLMJudgeModel):
-    """OpenAI model."""
+    """Supports any model that conforms to the OpenAI API spec."""
     def __init__(self, model_name: str, api_key: str):
         self.model_name = model_name
         openai.api_key = api_key
@@ -17,7 +21,7 @@ class OpenAIModel(LLMJudgeModel):
 
     def call(self, prompt: str, model_kwargs=None) -> str:
         """
-        Call the OpenAI model with the given prompt.
+        Call the OpenAI API compatible model with the given prompt.
 
         Args:
             prompt (str): The input prompt for the model
@@ -56,11 +60,11 @@ class OpenAIModel(LLMJudgeModel):
 
     def parse(self, prompt: str, response_format: BaseModel):
         completion = self.client.beta.chat.completions.parse(
-            model="gpt-4o-mini",  # Use appropriate model
+            model=self.model_name,  # Use appropriate model
             messages=[
                 {
                     "role": "system",
-                    "content": "You are a helpful assistant that categorizes items as either 'vital' or 'okay'."
+                    "content": "You are a helpful assistant that follows user instructions precisely and provides accurate information."
                 },
                 {
                     "role": "user",
@@ -72,4 +76,68 @@ class OpenAIModel(LLMJudgeModel):
 
         message = completion.choices[0].message
 
-        return message
+        return message.parsed
+
+
+class GeminiModel(LLMJudgeModel):
+    """LLMJudge that supports Google Gemini models."""
+    def __init__(self, model_name: str, api_key: str):
+        self.model_name = model_name
+        self.client = genai.Client(api_key=api_key)
+
+
+    def call(self, prompt: str, model_kwargs=None) -> str:
+        """
+        Call the Gemini API model with the given prompt.
+
+        Args:
+            prompt (str): The input prompt for the model
+            model_kwargs (dict, optional): Additional kwargs for the API call
+
+        Returns:
+            str: The model's response text
+
+        Raises:
+            ValueError: If the prompt is empty or model_kwargs is invalid
+            Exception: For API or other unexpected errors
+        """
+        if not prompt.strip():
+            raise ValueError("Prompt cannot be empty")
+
+        model_kwargs = model_kwargs or {}
+
+        try:
+            response = self.client.models.generate_content(
+                model=self.model_name,
+                contents=prompt,
+                **model_kwargs
+            )
+            return response.text
+        except Exception as e:
+            raise Exception(f"Unexpected error: {str(e)}") from e
+        
+
+    def parse(self, prompt: str, response_format: BaseModel):
+        """
+        Parse structured output from a Gemini model according to a Pydantic schema.
+
+        Args:
+            prompt (str): The input prompt
+            response_format (BaseModel): Pydantic model defining the expected response structure
+
+        Returns:
+            The parsed response matching the provided schema
+        """
+        response = self.client.models.generate_content(
+            model=self.model_name,
+            contents=prompt,
+            config={
+                'response_mime_type': 'application/json',
+                'response_schema': response_format,
+            },
+        )
+
+        response_json = json.loads(response.text)
+        parsed_response = parse_obj_as(response_format, response_json)
+
+        return parsed_response

--- a/open_rag_eval/models/llm_judges.py
+++ b/open_rag_eval/models/llm_judges.py
@@ -1,10 +1,9 @@
-import json
-import openai
-
 from abc import ABC
+import json
+
+import openai
 from google import genai
-from pydantic import BaseModel
-from pydantic.tools import parse_obj_as
+from pydantic import BaseModel, parse_obj_as
 
 
 class LLMJudgeModel(ABC):
@@ -14,10 +13,10 @@ class LLMJudgeModel(ABC):
 
 class OpenAIModel(LLMJudgeModel):
     """Supports any model that conforms to the OpenAI API spec."""
-    def __init__(self, model_name: str, api_key: str):
+    def __init__(self, model_name: str, api_key: str, base_url: str = None):
         self.model_name = model_name
         openai.api_key = api_key
-        self.client = openai.OpenAI()
+        self.client = openai.OpenAI(base_url=base_url)
 
     def call(self, prompt: str, model_kwargs=None) -> str:
         """
@@ -85,7 +84,6 @@ class GeminiModel(LLMJudgeModel):
         self.model_name = model_name
         self.client = genai.Client(api_key=api_key)
 
-
     def call(self, prompt: str, model_kwargs=None) -> str:
         """
         Call the Gemini API model with the given prompt.
@@ -115,7 +113,6 @@ class GeminiModel(LLMJudgeModel):
             return response.text
         except Exception as e:
             raise Exception(f"Unexpected error: {str(e)}") from e
-        
 
     def parse(self, prompt: str, response_format: BaseModel):
         """

--- a/open_rag_eval/run_eval.py
+++ b/open_rag_eval/run_eval.py
@@ -31,13 +31,17 @@ def get_evaluator(config: Dict[str, Any]) -> evaluators.Evaluator:
 
         # Create the model instance based on config
         model_config = config.evaluator.model
-        if model_config.type.lower() == "openai":
-            model = models.OpenAIModel(
-                model_name=model_config.name,
-                api_key=model_config.api_key
-            )
-        else:
-            raise ValueError(f"Unknown model type: {model_config.type}")
+        model_class = getattr(models, model_config.type)
+        
+        # Verify it's a subclass of LLMJudgeModel
+        if not issubclass(model_class, models.LLMJudgeModel):
+            raise TypeError(f"{model_config.type} is not a subclass of LLMJudgeModel")
+
+        # Instantiate the model with config parameters
+        model = model_class(
+            model_name=model_config.name,
+            api_key=model_config.api_key
+        )
 
         # Instantiate the evaluator with the model
         return evaluator_class(model=model)

--- a/open_rag_eval/run_eval.py
+++ b/open_rag_eval/run_eval.py
@@ -32,7 +32,7 @@ def get_evaluator(config: Dict[str, Any]) -> evaluators.Evaluator:
         # Create the model instance based on config
         model_config = config.evaluator.model
         model_class = getattr(models, model_config.type)
-        
+
         # Verify it's a subclass of LLMJudgeModel
         if not issubclass(model_class, models.LLMJudgeModel):
             raise TypeError(f"{model_config.type} is not a subclass of LLMJudgeModel")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 flask==3.0.3
 flask-cors==4.0.1
+google-genai~=1.10.0
 matplotlib~=3.10.1
 omegaconf~=2.3.0
 openai==1.61.1

--- a/tests/test_autonugget_metric.py
+++ b/tests/test_autonugget_metric.py
@@ -24,8 +24,7 @@ class TestAutoNuggetMetric(unittest.TestCase):
         umbrela_scores = {"1": 2, "2": 1 ,"3": 0}
 
         mock_response = Mock()
-        mock_response.parsed = Nuggets(nuggets=["nugget1", "nugget2"])
-        mock_response.refusal = None
+        mock_response = Nuggets(nuggets=["nugget1", "nugget2"])
         self.model.parse.return_value = mock_response
 
         nuggets = self.metric._create_nuggets(query, retrieved_passages, umbrela_scores)
@@ -36,12 +35,11 @@ class TestAutoNuggetMetric(unittest.TestCase):
         nuggets = ["nugget1", "nugget2", "nugget3"]
 
         mock_response = Mock()
-        mock_response.parsed = NuggetImportance(importance=[
+        mock_response = NuggetImportance(importance=[
             NuggetImportanceValues.VITAL,
             NuggetImportanceValues.OKAY,
             NuggetImportanceValues.VITAL
         ])
-        mock_response.refusal = None
         self.model.parse.return_value = mock_response
 
         sorted_nuggets, sorted_labels = self.metric._score_and_sort_nuggets(query, nuggets)
@@ -54,11 +52,10 @@ class TestAutoNuggetMetric(unittest.TestCase):
         nuggets = ["nugget1", "nugget2"]
 
         mock_response = Mock()
-        mock_response.parsed = NuggetAssignment(assignment=[
+        mock_response = NuggetAssignment(assignment=[
             NuggetAssignmentValues.SUPPORT,
             NuggetAssignmentValues.PARTIAL_SUPPORT
         ])
-        mock_response.refusal = None
         self.model.parse.return_value = mock_response
 
         assignments = self.metric._assign_nuggets(query, generated_answer, nuggets)

--- a/tests/test_llm_judges_integration.py
+++ b/tests/test_llm_judges_integration.py
@@ -13,6 +13,7 @@ class CitationSupportValues(str, Enum):
     PARTIAL = "partial_support"
     NONE = "no_support"
 
+
 class CitationSupport(BaseModel):
     support: CitationSupportValues
 
@@ -49,51 +50,49 @@ _STRUCTURED_OUTPUT_TEST_PROMPT = """
     Citation: {citation}
 """
 
+
 class TestLLMJudgesIntegration(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         load_dotenv()
         # Check for required environment variables
-        required_vars = {
-            "openai": ["OPENAI_API_KEY"],
-            "gemini": ["GOOGLE_API_KEY"]
-        }
-        
+        required_vars = {"openai": ["OPENAI_API_KEY"], "gemini": ["GOOGLE_API_KEY"]}
+
         cls.available_models = []
-        
+
         # Check OpenAI credentials
         if all(os.getenv(var) for var in required_vars["openai"]):
             cls.openai_key = os.getenv("OPENAI_API_KEY")
             cls.available_models.append("openai")
-        
+
         # Check Gemini credentials
         if all(os.getenv(var) for var in required_vars["gemini"]):
             cls.gemini_key = os.getenv("GOOGLE_API_KEY")
             cls.available_models.append("gemini")
-            
+
         if not cls.available_models:
-            raise unittest.SkipTest("Skipping LLMJudge integration tests - no API keys configured")
+            raise unittest.SkipTest(
+                "Skipping LLMJudge integration tests - no API keys configured"
+            )
 
     def setUp(self):
         if "openai" in self.available_models:
             self.openai_model = OpenAIModel(
-                model_name="gpt-4o-mini",
-                api_key=self.openai_key
+                model_name="gpt-4o-mini", api_key=self.openai_key
             )
         if "gemini" in self.available_models:
             self.gemini_model = GeminiModel(
-                model_name="gemini-2.0-flash",
-                api_key=self.gemini_key
+                model_name="gemini-2.0-flash", api_key=self.gemini_key
             )
 
     def test_openai_integration(self):
         """Test OpenAI model with actual API calls"""
         if "openai" not in self.available_models:
             self.skipTest("OpenAI API key not configured")
-            
+
         prompt = "What is 2+2? Answer with just the number."
         response = self.openai_model.call(prompt)
-        
+
         # Basic validation of response
         self.assertIsInstance(response, str)
         self.assertTrue(len(response.strip()) > 0)
@@ -104,10 +103,10 @@ class TestLLMJudgesIntegration(unittest.TestCase):
         """Test Gemini model with actual API calls"""
         if "gemini" not in self.available_models:
             self.skipTest("Gemini API key not configured")
-            
+
         prompt = "What is 2+2? Answer with just the number."
         response = self.gemini_model.call(prompt)
-        
+
         # Basic validation of response
         self.assertIsInstance(response, str)
         self.assertTrue(len(response.strip()) > 0)
@@ -118,13 +117,15 @@ class TestLLMJudgesIntegration(unittest.TestCase):
         """Test OpenAI model parse method with actual API calls"""
         if "openai" not in self.available_models:
             self.skipTest("OpenAI API key not configured")
-            
+
         statement = "The sky is blue."
         citation = "According to meteorological observations, the sky appears blue due to Rayleigh scattering of sunlight."
-        prompt = _STRUCTURED_OUTPUT_TEST_PROMPT.format(statement=statement, citation=citation)
-        
+        prompt = _STRUCTURED_OUTPUT_TEST_PROMPT.format(
+            statement=statement, citation=citation
+        )
+
         response = self.openai_model.parse(prompt, CitationSupport)
-        
+
         self.assertIsInstance(response, CitationSupport)
         self.assertIsInstance(response.support, CitationSupportValues)
         self.assertIn(response.support, CitationSupportValues)
@@ -133,16 +134,19 @@ class TestLLMJudgesIntegration(unittest.TestCase):
         """Test Gemini model parse method with actual API calls"""
         if "gemini" not in self.available_models:
             self.skipTest("Gemini API key not configured")
-            
+
         statement = "The sky is blue."
         citation = "According to meteorological observations, the sky appears blue due to Rayleigh scattering of sunlight."
-        prompt = _STRUCTURED_OUTPUT_TEST_PROMPT.format(statement=statement, citation=citation)
-        
-        response = self.gemini_model.parse(prompt, CitationSupport)    
-        
+        prompt = _STRUCTURED_OUTPUT_TEST_PROMPT.format(
+            statement=statement, citation=citation
+        )
+
+        response = self.gemini_model.parse(prompt, CitationSupport)
+
         self.assertIsInstance(response, CitationSupport)
         self.assertIsInstance(response.support, CitationSupportValues)
         self.assertIn(response.support, CitationSupportValues)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_llm_judges_integration.py
+++ b/tests/test_llm_judges_integration.py
@@ -1,0 +1,148 @@
+import os
+import unittest
+
+from dotenv import load_dotenv
+from enum import Enum
+from pydantic import BaseModel
+
+from open_rag_eval.models.llm_judges import OpenAIModel, GeminiModel
+
+
+class CitationSupportValues(str, Enum):
+    FULL = "full_support"
+    PARTIAL = "partial_support"
+    NONE = "no_support"
+
+class CitationSupport(BaseModel):
+    support: CitationSupportValues
+
+
+_STRUCTURED_OUTPUT_TEST_PROMPT = """
+    In this task, you will evaluate whether each statement is
+    supported by its corresponding citations. Note that the system
+    responses may appear very fluent and well-formed, but contain
+    slight inaccuracies that are not easy to discern at first glance.
+    Pay close attention to the text.
+
+    You will be provided with a statement and its corresponding
+    citation. It may be helpful to ask yourself whether it is
+    accurate to say "according to the citation" with a
+    statement following this phrase. Be sure to check all of the
+    information in the statement. You will be given three options:
+
+    - Full Support: All of the information in the statement is
+    supported in the citation.
+
+    - Partial Support: Some parts of the information are supported in
+    the citation, but other parts are missing from the citation.
+
+    - No Support: This citation does not support any part of the
+    statement.
+
+    Please provide your response based on the information in the
+    citation. If you are unsure, use your best judgment. Respond as
+    either ``full_support'', ``partial_support'', or ``no_support''
+    with no additional information.
+
+    Statement: {statement}
+
+    Citation: {citation}
+"""
+
+class TestLLMJudgesIntegration(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        load_dotenv()
+        # Check for required environment variables
+        required_vars = {
+            "openai": ["OPENAI_API_KEY"],
+            "gemini": ["GOOGLE_API_KEY"]
+        }
+        
+        cls.available_models = []
+        
+        # Check OpenAI credentials
+        if all(os.getenv(var) for var in required_vars["openai"]):
+            cls.openai_key = os.getenv("OPENAI_API_KEY")
+            cls.available_models.append("openai")
+        
+        # Check Gemini credentials
+        if all(os.getenv(var) for var in required_vars["gemini"]):
+            cls.gemini_key = os.getenv("GOOGLE_API_KEY")
+            cls.available_models.append("gemini")
+            
+        if not cls.available_models:
+            raise unittest.SkipTest("Skipping LLMJudge integration tests - no API keys configured")
+
+    def setUp(self):
+        if "openai" in self.available_models:
+            self.openai_model = OpenAIModel(
+                model_name="gpt-4o-mini",
+                api_key=self.openai_key
+            )
+        if "gemini" in self.available_models:
+            self.gemini_model = GeminiModel(
+                model_name="gemini-2.0-flash",
+                api_key=self.gemini_key
+            )
+
+    def test_openai_integration(self):
+        """Test OpenAI model with actual API calls"""
+        if "openai" not in self.available_models:
+            self.skipTest("OpenAI API key not configured")
+            
+        prompt = "What is 2+2? Answer with just the number."
+        response = self.openai_model.call(prompt)
+        
+        # Basic validation of response
+        self.assertIsInstance(response, str)
+        self.assertTrue(len(response.strip()) > 0)
+        # The response should contain 4 somewhere
+        self.assertIn("4", response)
+
+    def test_gemini_integration(self):
+        """Test Gemini model with actual API calls"""
+        if "gemini" not in self.available_models:
+            self.skipTest("Gemini API key not configured")
+            
+        prompt = "What is 2+2? Answer with just the number."
+        response = self.gemini_model.call(prompt)
+        
+        # Basic validation of response
+        self.assertIsInstance(response, str)
+        self.assertTrue(len(response.strip()) > 0)
+        # The response should contain 4 somewhere
+        self.assertIn("4", response)
+
+    def test_openai_parse_integration(self):
+        """Test OpenAI model parse method with actual API calls"""
+        if "openai" not in self.available_models:
+            self.skipTest("OpenAI API key not configured")
+            
+        statement = "The sky is blue."
+        citation = "According to meteorological observations, the sky appears blue due to Rayleigh scattering of sunlight."
+        prompt = _STRUCTURED_OUTPUT_TEST_PROMPT.format(statement=statement, citation=citation)
+        
+        response = self.openai_model.parse(prompt, CitationSupport)
+        
+        self.assertIsInstance(response, CitationSupport)
+        self.assertIsInstance(response.support, CitationSupportValues)
+        self.assertIn(response.support, CitationSupportValues)
+
+    def test_gemini_parse_integration(self):
+        """Test Gemini model parse method with actual API calls"""
+        if "gemini" not in self.available_models:
+            self.skipTest("Gemini API key not configured")
+            
+        statement = "The sky is blue."
+        citation = "According to meteorological observations, the sky appears blue due to Rayleigh scattering of sunlight."
+        prompt = _STRUCTURED_OUTPUT_TEST_PROMPT.format(statement=statement, citation=citation)
+        
+        response = self.gemini_model.parse(prompt, CitationSupport)    
+        
+        self.assertIsInstance(response, CitationSupport)
+        self.assertIsInstance(response.support, CitationSupportValues)
+        self.assertIn(response.support, CitationSupportValues)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This can be selected for example by using the following config:

```
evaluator:
  type: "TRECEvaluator"  
  model:
    type: "GeminiModel"
    name: "gemini-2.0-flash"
    api_key: ${oc.env:GOOGLE_API_KEY}  # Reads from environment variable.
```