### PR TITLE
Set temp=0

### DIFF
--- a/open_rag_eval/connectors/vectara_connector.py
+++ b/open_rag_eval/connectors/vectara_connector.py
@@ -82,7 +82,7 @@ class VectaraConnector(Connector):
                 generated_answer = data.get("summary", "")
 
                 if not generated_answer:
-                    # Skip queries with no generated answer.
+                    print(f"No generated answer for query {query['query']}. Skipping...")
                     continue
 
                 # Get the search results.

--- a/open_rag_eval/metrics/autonugget_metric.py
+++ b/open_rag_eval/metrics/autonugget_metric.py
@@ -112,6 +112,9 @@ class AutoNuggetMetric(AugmentedGenerationMetric):
             "partial_support": 0.5,
             "not_support": 0.0,
         }
+        self.model_kwargs = {
+            "temperature": 0.0,
+        }
 
     def compute(
         self, rag_result: RAGResult, umbrela_scores: Dict[str, int]
@@ -180,7 +183,11 @@ class AutoNuggetMetric(AugmentedGenerationMetric):
                 max_nuggets=self.max_nuggets,
             )
             try:
-                response = self.model.parse(prompt, response_format=Nuggets)
+                response = self.model.parse(
+                    prompt, 
+                    response_format=Nuggets,
+                    model_kwargs=self.model_kwargs
+                )
             except Exception as e:
                 logging.error(f"Failed to create nuggets: {e}")
                 raise e
@@ -220,7 +227,11 @@ class AutoNuggetMetric(AugmentedGenerationMetric):
                 nuggets=nuggets[i : i + 10],
             )
             try:
-                response = self.model.parse(prompt, response_format=NuggetImportance)
+                response = self.model.parse(
+                    prompt, 
+                    response_format=NuggetImportance,
+                    model_kwargs=self.model_kwargs
+                )
             except Exception as e:
                 logging.error(f"Failed to create nuggets: {e}")
                 raise e
@@ -267,7 +278,11 @@ class AutoNuggetMetric(AugmentedGenerationMetric):
                 generated_passage=generated_passage,
             )
             try:
-                response = self.model.parse(prompt, response_format=NuggetAssignment)
+                response = self.model.parse(
+                    prompt, 
+                    response_format=NuggetAssignment,
+                    model_kwargs=self.model_kwargs
+                )
             except Exception as e:
                 logging.error(f"Failed to create nuggets: {e}")
                 raise e

--- a/open_rag_eval/metrics/autonugget_metric.py
+++ b/open_rag_eval/metrics/autonugget_metric.py
@@ -114,6 +114,7 @@ class AutoNuggetMetric(AugmentedGenerationMetric):
         }
         self.model_kwargs = {
             "temperature": 0.0,
+            "seed": 42
         }
 
     def compute(

--- a/open_rag_eval/metrics/autonugget_metric.py
+++ b/open_rag_eval/metrics/autonugget_metric.py
@@ -184,7 +184,7 @@ class AutoNuggetMetric(AugmentedGenerationMetric):
             )
             try:
                 response = self.model.parse(
-                    prompt, 
+                    prompt,
                     response_format=Nuggets,
                     model_kwargs=self.model_kwargs
                 )
@@ -228,7 +228,7 @@ class AutoNuggetMetric(AugmentedGenerationMetric):
             )
             try:
                 response = self.model.parse(
-                    prompt, 
+                    prompt,
                     response_format=NuggetImportance,
                     model_kwargs=self.model_kwargs
                 )
@@ -250,8 +250,8 @@ class AutoNuggetMetric(AugmentedGenerationMetric):
             raise ValueError("Number of labels does not match number of nuggets.")
         sorted_pairs = sorted(zip(nuggets, labels), key=lambda x: x[1] == "okay")
         sorted_nuggets, sorted_labels = zip(*sorted_pairs)
-        N_nuggets = 20
-        return list(sorted_nuggets[:N_nuggets]), list(sorted_labels[:N_nuggets])
+        n_nuggets = 20      # return top 20 nuggets, as per the paper implementation.
+        return list(sorted_nuggets[:n_nuggets]), list(sorted_labels[:n_nuggets])
 
     def _assign_nuggets(
         self, query: str, generated_answer: Dict[str, str], nuggets: List[str]
@@ -280,7 +280,7 @@ class AutoNuggetMetric(AugmentedGenerationMetric):
             )
             try:
                 response = self.model.parse(
-                    prompt, 
+                    prompt,
                     response_format=NuggetAssignment,
                     model_kwargs=self.model_kwargs
                 )

--- a/open_rag_eval/metrics/autonugget_metric.py
+++ b/open_rag_eval/metrics/autonugget_metric.py
@@ -233,24 +233,25 @@ class AutoNuggetMetric(AugmentedGenerationMetric):
                     model_kwargs=self.model_kwargs
                 )
             except Exception as e:
-                logging.error(f"Failed to create nuggets: {e}")
+                logging.error(f"Failed to evaluate nuggets: {e}")
                 raise e
 
             if response.importance:
                 labels.extend(response.importance)
             else:
                 logging.error(
-                    f"Failed to score nuggets from response: {response.refusal} for query {query}."
+                    f"Failed to evaluate nuggets from response: {response.refusal} for query {query}."
                 )
                 raise ValueError(
-                    f"Failed to score nuggets from response: {response.refusal} for query {query}."
+                    f"Failed to evaluate nuggets from response: {response.refusal} for query {query}."
                 )
 
         if len(labels) != len(nuggets):
             raise ValueError("Number of labels does not match number of nuggets.")
         sorted_pairs = sorted(zip(nuggets, labels), key=lambda x: x[1] == "okay")
         sorted_nuggets, sorted_labels = zip(*sorted_pairs)
-        return list(sorted_nuggets[:20]), list(sorted_labels[:20])
+        N_nuggets = 20
+        return list(sorted_nuggets[:N_nuggets]), list(sorted_labels[:N_nuggets])
 
     def _assign_nuggets(
         self, query: str, generated_answer: Dict[str, str], nuggets: List[str]
@@ -284,7 +285,7 @@ class AutoNuggetMetric(AugmentedGenerationMetric):
                     model_kwargs=self.model_kwargs
                 )
             except Exception as e:
-                logging.error(f"Failed to create nuggets: {e}")
+                logging.error(f"Failed to assign nuggets: {e}")
                 raise e
             if response.assignment:
                 assignments.extend(response.assignment)

--- a/open_rag_eval/metrics/citation_metric.py
+++ b/open_rag_eval/metrics/citation_metric.py
@@ -91,7 +91,11 @@ class CitationMetric(AugmentedGenerationMetric):
                 prompt = self._CITATION_PROMPT.format(
                     statement=answer_sentence, citation=passage
                 )
-                response = self.model.parse(prompt, response_format=CitationSupport)
+                response = self.model.parse(
+                    prompt, 
+                    response_format=CitationSupport,
+                    model_kwargs = {"temperature": 0.0}
+                )
                 if not response.support:
                     logging.error(
                         "While calculating citation metrics: "

--- a/open_rag_eval/metrics/citation_metric.py
+++ b/open_rag_eval/metrics/citation_metric.py
@@ -94,7 +94,7 @@ class CitationMetric(AugmentedGenerationMetric):
                 response = self.model.parse(
                     prompt,
                     response_format=CitationSupport,
-                    model_kwargs = {"temperature": 0.0}
+                    model_kwargs={"temperature": 0.0}
                 )
                 if not response.support:
                     logging.error(

--- a/open_rag_eval/metrics/citation_metric.py
+++ b/open_rag_eval/metrics/citation_metric.py
@@ -94,7 +94,10 @@ class CitationMetric(AugmentedGenerationMetric):
                 response = self.model.parse(
                     prompt,
                     response_format=CitationSupport,
-                    model_kwargs={"temperature": 0.0}
+                    model_kwargs={
+                        "temperature": 0.0,
+                        "seed": 42
+                    }
                 )
                 if not response.support:
                     logging.error(

--- a/open_rag_eval/metrics/citation_metric.py
+++ b/open_rag_eval/metrics/citation_metric.py
@@ -92,7 +92,7 @@ class CitationMetric(AugmentedGenerationMetric):
                     statement=answer_sentence, citation=passage
                 )
                 response = self.model.parse(
-                    prompt, 
+                    prompt,
                     response_format=CitationSupport,
                     model_kwargs = {"temperature": 0.0}
                 )

--- a/open_rag_eval/metrics/no_answer_metric.py
+++ b/open_rag_eval/metrics/no_answer_metric.py
@@ -89,7 +89,10 @@ class NoAnswerMetric(AugmentedGenerationMetric):
             response = self.model.parse(
                 prompt,
                 response_format=QueryAnswered,
-                model_kwargs={"temperature": 0.0},
+                model_kwargs={
+                    "temperature": 0.0,
+                    "seed": 42
+                },
             )
             if not response.answered:
                 raise ValueError(f"Failed to parse response: {response.refusal}")

--- a/open_rag_eval/metrics/no_answer_metric.py
+++ b/open_rag_eval/metrics/no_answer_metric.py
@@ -86,7 +86,11 @@ class NoAnswerMetric(AugmentedGenerationMetric):
             prompt = self._ANSWERED_PROMPT.format(
                 query=generation_result.query, answer=summary
             )
-            response = self.model.parse(prompt, response_format=QueryAnswered)
+            response = self.model.parse(
+                prompt, 
+                response_format=QueryAnswered,
+                model_kwargs={"temperature": 0.0},
+            )
             if not response.answered:
                 raise ValueError(f"Failed to parse response: {response.refusal}")
 

--- a/open_rag_eval/metrics/no_answer_metric.py
+++ b/open_rag_eval/metrics/no_answer_metric.py
@@ -87,7 +87,7 @@ class NoAnswerMetric(AugmentedGenerationMetric):
                 query=generation_result.query, answer=summary
             )
             response = self.model.parse(
-                prompt, 
+                prompt,
                 response_format=QueryAnswered,
                 model_kwargs={"temperature": 0.0},
             )


### PR DESCRIPTION
Per discussion with Ronak 
"I used a temperature of 0 in the paper, but these results are not consistent with MoEs even in temperature of 0"
Even though temp=0 doesn't guarantee consistency 100% it's better than temp>0 in that sense, so this PR updates to Temp=0 for AutoNugger metric and also for citation and no-answer metrics.