### PR TITLE
Minimal fix to .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,9 +1,9 @@
 .git
 .gitignore
-__pycache__/
-*.py[cod]
-*$py.class
-*.so
+**/__pycache__/
+**/*.py[cod]
+**/*$py.class
+**/*.so
 .Python
 env/
 build/


### PR DESCRIPTION
This PR fixes .dockerignore misconfigurations (#140).

- I added `**/` at the beginning of the patterns I thought should match recursively
- Please let me know if any other lines should include `**/` as well.