### PR TITLE
Remove unused import of 'os' in hallucination_metric.py

### DIFF
--- a/open_rag_eval/metrics/hallucination_metric.py
+++ b/open_rag_eval/metrics/hallucination_metric.py
@@ -1,4 +1,3 @@
-import os
 from typing import Dict
 
 from open_rag_eval.metrics.base_metrics import AugmentedGenerationMetric


### PR DESCRIPTION
Removed unused import statement for 'os'.