### PR TITLE
Add token usage tracking across all LLM metrics

### DIFF
--- a/open_rag_eval/_version.py
+++ b/open_rag_eval/_version.py
@@ -1,4 +1,4 @@
 """
 Define the version of the package.
 """
-__version__ = "0.2.4"
+__version__ = "0.3.0"

--- a/open_rag_eval/evaluators/trec_evaluator.py
+++ b/open_rag_eval/evaluators/trec_evaluator.py
@@ -86,6 +86,40 @@ class TRECEvaluator(Evaluator):
                 no_answer_score = self.no_answer_metric.compute(
                     rag_result.generation_result)
 
+                # Aggregate token usage from all metrics
+                total_input_tokens = 0
+                total_output_tokens = 0
+
+                # UMBRELA tokens (retrieval)
+                umbrela_tokens = retrieval_scores.get("token_usage", {})
+                total_input_tokens += umbrela_tokens.get("input_tokens", 0)
+                total_output_tokens += umbrela_tokens.get("output_tokens", 0)
+
+                # AutoNugget tokens (generation)
+                autonugget_tokens = autonugget_scores.get("token_usage", {})
+                total_input_tokens += autonugget_tokens.get("input_tokens", 0)
+                total_output_tokens += autonugget_tokens.get("output_tokens", 0)
+
+                # Citation tokens (generation)
+                citation_tokens = citation_scores.get("token_usage", {})
+                total_input_tokens += citation_tokens.get("input_tokens", 0)
+                total_output_tokens += citation_tokens.get("output_tokens", 0)
+
+                # NoAnswer tokens (generation)
+                no_answer_tokens = no_answer_score.get("token_usage", {})
+                total_input_tokens += no_answer_tokens.get("input_tokens", 0)
+                total_output_tokens += no_answer_tokens.get("output_tokens", 0)
+
+                aggregated_token_usage = {
+                    "umbrela_tokens": umbrela_tokens,
+                    "autonugget_tokens": autonugget_tokens,
+                    "citation_tokens": citation_tokens,
+                    "no_answer_tokens": no_answer_tokens,
+                    "total_input_tokens": total_input_tokens,
+                    "total_output_tokens": total_output_tokens,
+                    "total_tokens": total_input_tokens + total_output_tokens
+                }
+
                 # Create aggregate scores
                 mean_umbrela_score = sum(
                     umbrela_scores.values()) / len(umbrela_scores)
@@ -113,6 +147,8 @@ class TRECEvaluator(Evaluator):
                                 retrieval_scores["retrieval_scores"],
                             "mean_umbrela_score":
                                 mean_umbrela_score,
+                            "token_usage":
+                                umbrela_tokens,
                         }),
                     AugmentedGenerationScores(
                         scores={
@@ -130,6 +166,8 @@ class TRECEvaluator(Evaluator):
                                 citation_scores["f1"],
                             "no_answer_score":
                                 no_answer_score,
+                            "token_usage":
+                                aggregated_token_usage,
                         }),
                 )
 
@@ -395,6 +433,13 @@ class TRECEvaluator(Evaluator):
                         result_dict[
                             f"{run_id}generation_score_{key}"] = json.dumps(
                                 value)
+
+                    # Add flattened token usage columns for easier analysis
+                    token_usage = result.scores.generation_score.scores.get("token_usage", {})
+                    if token_usage:
+                        result_dict[f"{run_id}total_input_tokens"] = token_usage.get("total_input_tokens", 0)
+                        result_dict[f"{run_id}total_output_tokens"] = token_usage.get("total_output_tokens", 0)
+                        result_dict[f"{run_id}total_tokens"] = token_usage.get("total_tokens", 0)
 
             results_dict.append(result_dict)
 

--- a/open_rag_eval/metrics/autonugget_metric.py
+++ b/open_rag_eval/metrics/autonugget_metric.py
@@ -180,7 +180,7 @@ class AutoNuggetMetric(AugmentedGenerationMetric):
         query: str,
         retrieved_passages: Dict[str, str],
         umbrela_scores: Dict[str, int],
-    ) -> tuple[List[str], dict]:
+    ) -> Tuple[List[str], Dict[str, int]]:
         """
         Creates nuggets (concise information units) from retrieved passages based on a query.
 
@@ -252,7 +252,7 @@ class AutoNuggetMetric(AugmentedGenerationMetric):
 
     def _score_and_sort_nuggets(
         self, query: str, nuggets: List[str]
-    ) -> tuple[Tuple[List[str], List[str]], dict]:
+    ) -> Tuple[Tuple[List[str], List[str]], Dict[str, int]]:
         """
         Evaluates and ranks a list of text nuggets based on their relevance to a query.
         Processes nuggets in batches of 10, scores them using an LLM, and returns the top
@@ -321,7 +321,7 @@ class AutoNuggetMetric(AugmentedGenerationMetric):
 
     def _assign_nuggets(
         self, query: str, generated_answer: Dict[str, str], nuggets: List[str]
-    ) -> tuple[List[str], dict]:
+    ) -> Tuple[List[str], Dict[str, int]]:
         """Evaluates how well each nugget is covered in the generated passage by assigning
         support/partial_support/not_support labels
 

--- a/open_rag_eval/metrics/autonugget_metric.py
+++ b/open_rag_eval/metrics/autonugget_metric.py
@@ -122,19 +122,34 @@ class AutoNuggetMetric(AugmentedGenerationMetric):
     ) -> Dict[str, int]:
         retrieval_result = rag_result.retrieval_result
         try:
-            nuggets = self._create_nuggets(
+            # Track total token usage across all three steps
+            total_input_tokens = 0
+            total_output_tokens = 0
+
+            # Step 1: Create nuggets
+            nuggets, create_tokens = self._create_nuggets(
                 retrieval_result.query,
                 retrieval_result.retrieved_passages,
                 umbrela_scores,
             )
-            sorted_nuggets, sorted_labels = self._score_and_sort_nuggets(
+            total_input_tokens += create_tokens.get("input_tokens", 0)
+            total_output_tokens += create_tokens.get("output_tokens", 0)
+
+            # Step 2: Score and sort nuggets
+            (sorted_nuggets, sorted_labels), score_tokens = self._score_and_sort_nuggets(
                 retrieval_result.query, nuggets
             )
-            nugget_assignments = self._assign_nuggets(
+            total_input_tokens += score_tokens.get("input_tokens", 0)
+            total_output_tokens += score_tokens.get("output_tokens", 0)
+
+            # Step 3: Assign nuggets
+            nugget_assignments, assign_tokens = self._assign_nuggets(
                 rag_result.generation_result.query,
                 rag_result.generation_result.generated_answer,
                 sorted_nuggets,
             )
+            total_input_tokens += assign_tokens.get("input_tokens", 0)
+            total_output_tokens += assign_tokens.get("output_tokens", 0)
 
             scores = {}
             scores["nuggetizer_scores"] = self._evaluate_answer(
@@ -148,6 +163,13 @@ class AutoNuggetMetric(AugmentedGenerationMetric):
                 for assignment in nugget_assignments
             ]
 
+            # Add token usage to scores
+            scores["token_usage"] = {
+                "input_tokens": total_input_tokens,
+                "output_tokens": total_output_tokens,
+                "total_tokens": total_input_tokens + total_output_tokens
+            }
+
             return scores
         except Exception as e:
             logging.error("Failed to compute nugget metric: %s", str(e))
@@ -158,13 +180,15 @@ class AutoNuggetMetric(AugmentedGenerationMetric):
         query: str,
         retrieved_passages: Dict[str, str],
         umbrela_scores: Dict[str, int],
-    ) -> List[str]:
+    ) -> tuple[List[str], dict]:
         """
         Creates nuggets (concise information units) from retrieved passages based on a query.
 
         This method filters passages based on umbrella scores and iteratively generates nuggets
         using a language model until the maximum number of nuggets is reached or iterations complete.
 
+        Returns:
+            tuple: (nuggets list, token_usage dict)
         """
         if not query.strip():
             raise ValueError("Query cannot be empty.")
@@ -175,6 +199,11 @@ class AutoNuggetMetric(AugmentedGenerationMetric):
             f"[{i+1}] {seg}" for i, (_, seg) in enumerate(filtered_passages.items())
         )
         nuggets = []
+
+        # Track token usage
+        total_input_tokens = 0
+        total_output_tokens = 0
+
         for _ in range(self.nugget_creation_iters):
             prompt = self._NUGGET_CREATION_PROMPT.format(
                 query=query,
@@ -184,11 +213,18 @@ class AutoNuggetMetric(AugmentedGenerationMetric):
                 max_nuggets=self.max_nuggets,
             )
             try:
-                response = self.model.parse(
+                result = self.model.parse(
                     prompt,
                     response_format=Nuggets,
                     model_kwargs=self.model_kwargs
                 )
+                response = result["response"]
+                metadata = result["metadata"]
+
+                # Accumulate tokens
+                total_input_tokens += metadata.get("input_tokens", 0)
+                total_output_tokens += metadata.get("output_tokens", 0)
+
             except Exception as e:
                 logging.error(f"Failed to create nuggets: {e}")
                 raise e
@@ -206,21 +242,36 @@ class AutoNuggetMetric(AugmentedGenerationMetric):
             if len(nuggets) >= self.max_nuggets:
                 break
 
-        return nuggets
+        token_usage = {
+            "input_tokens": total_input_tokens,
+            "output_tokens": total_output_tokens,
+            "total_tokens": total_input_tokens + total_output_tokens
+        }
+
+        return nuggets, token_usage
 
     def _score_and_sort_nuggets(
         self, query: str, nuggets: List[str]
-    ) -> Tuple[List[str], List[str]]:
+    ) -> tuple[Tuple[List[str], List[str]], dict]:
         """
         Evaluates and ranks a list of text nuggets based on their relevance to a query.
         Processes nuggets in batches of 10, scores them using an LLM, and returns the top
         20 most relevant nuggets along with their importance labels.
+
+        Returns:
+            tuple: ((sorted_nuggets, sorted_labels), token_usage dict)
         """
         if not query.strip():
             raise ValueError("Query cannot be empty.")
         if not nuggets:
-            return [], []
+            return ([], []), {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+
         labels = []
+
+        # Track token usage
+        total_input_tokens = 0
+        total_output_tokens = 0
+
         for i in range(0, len(nuggets), 10):
             prompt = self._NUGGET_IMPORTANCE_PROMPT.format(
                 query=query,
@@ -228,11 +279,18 @@ class AutoNuggetMetric(AugmentedGenerationMetric):
                 nuggets=nuggets[i : i + 10],
             )
             try:
-                response = self.model.parse(
+                result = self.model.parse(
                     prompt,
                     response_format=NuggetImportance,
                     model_kwargs=self.model_kwargs
                 )
+                response = result["response"]
+                metadata = result["metadata"]
+
+                # Accumulate tokens
+                total_input_tokens += metadata.get("input_tokens", 0)
+                total_output_tokens += metadata.get("output_tokens", 0)
+
             except Exception as e:
                 logging.error(f"Failed to evaluate nuggets: {e}")
                 raise e
@@ -252,13 +310,24 @@ class AutoNuggetMetric(AugmentedGenerationMetric):
         sorted_pairs = sorted(zip(nuggets, labels), key=lambda x: x[1] == "okay")
         sorted_nuggets, sorted_labels = zip(*sorted_pairs)
         n_nuggets = 20      # return top 20 nuggets, as per the paper implementation.
-        return list(sorted_nuggets[:n_nuggets]), list(sorted_labels[:n_nuggets])
+
+        token_usage = {
+            "input_tokens": total_input_tokens,
+            "output_tokens": total_output_tokens,
+            "total_tokens": total_input_tokens + total_output_tokens
+        }
+
+        return (list(sorted_nuggets[:n_nuggets]), list(sorted_labels[:n_nuggets])), token_usage
 
     def _assign_nuggets(
         self, query: str, generated_answer: Dict[str, str], nuggets: List[str]
-    ) -> List[str]:
+    ) -> tuple[List[str], dict]:
         """Evaluates how well each nugget is covered in the generated passage by assigning
-        support/partial_support/not_support labels"""
+        support/partial_support/not_support labels
+
+        Returns:
+            tuple: (assignments list, token_usage dict)
+        """
 
         # Generated passage maps passage ID to passage text, we need to convert this to a single string.
         generated_passage = " ".join(
@@ -270,8 +339,14 @@ class AutoNuggetMetric(AugmentedGenerationMetric):
         if not generated_passage.strip():
             raise ValueError("Generated passage cannot be empty.")
         if not nuggets:
-            return []
+            return [], {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+
         assignments = []
+
+        # Track token usage
+        total_input_tokens = 0
+        total_output_tokens = 0
+
         for i in range(0, len(nuggets), 10):
             prompt = self._NUGGET_ASSIGNMENT_PROMPT.format(
                 query=query,
@@ -280,11 +355,18 @@ class AutoNuggetMetric(AugmentedGenerationMetric):
                 generated_passage=generated_passage,
             )
             try:
-                response = self.model.parse(
+                result = self.model.parse(
                     prompt,
                     response_format=NuggetAssignment,
                     model_kwargs=self.model_kwargs
                 )
+                response = result["response"]
+                metadata = result["metadata"]
+
+                # Accumulate tokens
+                total_input_tokens += metadata.get("input_tokens", 0)
+                total_output_tokens += metadata.get("output_tokens", 0)
+
             except Exception as e:
                 logging.error(f"Failed to assign nuggets: {e}")
                 raise e
@@ -300,7 +382,14 @@ class AutoNuggetMetric(AugmentedGenerationMetric):
 
         if len(assignments) != len(nuggets):
             raise ValueError("Number of assignments does not match number of nuggets.")
-        return assignments
+
+        token_usage = {
+            "input_tokens": total_input_tokens,
+            "output_tokens": total_output_tokens,
+            "total_tokens": total_input_tokens + total_output_tokens
+        }
+
+        return assignments, token_usage
 
     def _evaluate_answer(
         self, nuggets: List[str], labels: List[str], nugget_assignments: List[str]

--- a/open_rag_eval/metrics/citation_metric.py
+++ b/open_rag_eval/metrics/citation_metric.py
@@ -81,10 +81,15 @@ class CitationMetric(AugmentedGenerationMetric):
                 - weighted_recall: Sum of part average scores / total parts
                 - f1: Harmonic mean of precision and recall
                 - Individual citation and part scores
+                - token_usage: Token usage statistics
         """
 
         retrieval_result = rag_result.retrieval_result
         generation_result = rag_result.generation_result
+
+        # Track token usage
+        total_input_tokens = 0
+        total_output_tokens = 0
 
         citation_to_scores = defaultdict(list)
         part_to_scores = defaultdict(list)
@@ -110,7 +115,7 @@ class CitationMetric(AugmentedGenerationMetric):
                     prompt = self._CITATION_PROMPT.format(
                         statement=answer_sentence, citation=passage
                     )
-                    response = self.model.parse(
+                    result = self.model.parse(
                         prompt,
                         response_format=CitationSupport,
                         model_kwargs={
@@ -118,6 +123,13 @@ class CitationMetric(AugmentedGenerationMetric):
                             "seed": 42
                         }
                     )
+                    response = result["response"]
+                    metadata = result["metadata"]
+
+                    # Accumulate tokens
+                    total_input_tokens += metadata.get("input_tokens", 0)
+                    total_output_tokens += metadata.get("output_tokens", 0)
+
                     if not response.support:
                         logging.error(
                             "While calculating citation metrics: failed to parse response – %s",
@@ -161,5 +173,12 @@ class CitationMetric(AugmentedGenerationMetric):
             scores["f1"] = (
                 2 * (scores["weighted_precision"] * scores["weighted_recall"]) /
                 (scores["weighted_precision"] + scores["weighted_recall"]))
+
+        # Add token usage to scores
+        scores["token_usage"] = {
+            "input_tokens": total_input_tokens,
+            "output_tokens": total_output_tokens,
+            "total_tokens": total_input_tokens + total_output_tokens
+        }
 
         return scores

--- a/open_rag_eval/metrics/citation_metric.py
+++ b/open_rag_eval/metrics/citation_metric.py
@@ -95,14 +95,10 @@ class CitationMetric(AugmentedGenerationMetric):
         part_to_scores = defaultdict(list)
         for part_idx, generated_answer_part in enumerate(
                 generation_result.generated_answer, start=1):
-            answer_sentence, citations = (
-                generated_answer_part.text,
-                generated_answer_part.citations,
-            )
-            if len(citations) == 0:
+            if len(generated_answer_part.citations) == 0:
                 part_to_scores[f"part_score_{part_idx}"] = []
                 continue
-            for citation_key in citations:
+            for citation_key in generated_answer_part.citations:
                 try:
                     passage = retrieval_result.retrieved_passages.get(
                         citation_key, "")
@@ -113,7 +109,7 @@ class CitationMetric(AugmentedGenerationMetric):
                         continue
 
                     prompt = self._CITATION_PROMPT.format(
-                        statement=answer_sentence, citation=passage
+                        statement=generated_answer_part.text, citation=passage
                     )
                     result = self.model.parse(
                         prompt,
@@ -137,8 +133,7 @@ class CitationMetric(AugmentedGenerationMetric):
                         )
                         continue
 
-                    label = response.support.value
-                    score = self.score_map[label]
+                    score = self.score_map[response.support.value]
                     citation_to_scores[f"citation_score_{citation_key}"].append(
                         score)
                     part_to_scores[f"part_score_{part_idx}"].append(score)

--- a/open_rag_eval/metrics/no_answer_metric.py
+++ b/open_rag_eval/metrics/no_answer_metric.py
@@ -86,7 +86,7 @@ class NoAnswerMetric(AugmentedGenerationMetric):
             prompt = self._ANSWERED_PROMPT.format(
                 query=generation_result.query, answer=summary
             )
-            response = self.model.parse(
+            result = self.model.parse(
                 prompt,
                 response_format=QueryAnswered,
                 model_kwargs={
@@ -94,10 +94,21 @@ class NoAnswerMetric(AugmentedGenerationMetric):
                     "seed": 42
                 },
             )
+            response = result["response"]
+            metadata = result["metadata"]
+
             if not response.answered:
                 raise ValueError(f"Failed to parse response: {response.refusal}")
 
             scores["query_answered"] = response.answered.value
+
+            # Add token usage to scores
+            scores["token_usage"] = {
+                "input_tokens": metadata.get("input_tokens", 0),
+                "output_tokens": metadata.get("output_tokens", 0),
+                "total_tokens": metadata.get("total_tokens", 0)
+            }
+
         except Exception as e:
             raise Exception(f"Error computing NoAnswer metric: {str(e)}") from e
 

--- a/open_rag_eval/metrics/umbrela_metric.py
+++ b/open_rag_eval/metrics/umbrela_metric.py
@@ -105,6 +105,11 @@ class UMBRELAMetric(RetrievalMetric):
 
         scores["umbrela_scores"] = {}
         umbrela_scores = scores["umbrela_scores"]
+
+        # Track token usage across all passages
+        total_input_tokens = 0
+        total_output_tokens = 0
+
         for key, passage in retrieval_result.retrieved_passages.items():
             try:
                 query = retrieval_result.query
@@ -117,7 +122,14 @@ class UMBRELAMetric(RetrievalMetric):
                     )
                 else:
                     prompt = self._UMBRELA_PROMPT.format(query=query, passage=passage)
-                response = self.model.parse(prompt, UMBRELAScore, self.model_kwargs)
+
+                result = self.model.parse(prompt, UMBRELAScore, self.model_kwargs)
+                response = result["response"]
+                metadata = result["metadata"]
+
+                # Accumulate tokens
+                total_input_tokens += metadata.get("input_tokens", 0)
+                total_output_tokens += metadata.get("output_tokens", 0)
 
                 if not response.score:
                     raise ValueError(f"Failed to parse response: {response.refusal}")
@@ -126,6 +138,13 @@ class UMBRELAMetric(RetrievalMetric):
 
             except Exception as e:
                 raise Exception(f"Error computing UMBRELA score: {str(e)}") from e
+
+        # Add token usage to scores
+        scores["token_usage"] = {
+            "input_tokens": total_input_tokens,
+            "output_tokens": total_output_tokens,
+            "total_tokens": total_input_tokens + total_output_tokens
+        }
 
         # Calculate traditional retrieval metrics.
         self.add_retrieval_metrics(scores, k_values)

--- a/open_rag_eval/models/llm_judges.py
+++ b/open_rag_eval/models/llm_judges.py
@@ -39,13 +39,13 @@ class OpenAIModel(LLMJudgeModel):
                 openai.RateLimitError,
                 openai.APIConnectionError,
                 openai.APIError,
-                ValueError,  # catch our “none‐response” too
+                ValueError,  # catch our "none‐response" too
             )
         ),
         stop=stop_after_attempt(3),
         wait=wait_exponential(multiplier=1, min=1, max=10),
     )
-    def call(self, prompt: str, model_kwargs=None) -> str:
+    def call(self, prompt: str, model_kwargs=None) -> dict:
         """
         Call the OpenAI API compatible model with the given prompt.
 
@@ -54,7 +54,9 @@ class OpenAIModel(LLMJudgeModel):
             model_kwargs (dict, optional): Additional kwargs for the API call
 
         Returns:
-            str: The model's response text
+            dict: Dictionary containing:
+                - response (str): The model's response text
+                - metadata (dict): Token usage and model information
 
         Raises:
             ValueError: If the prompt is empty or model_kwargs is invalid
@@ -67,6 +69,7 @@ class OpenAIModel(LLMJudgeModel):
             raise ValueError("Prompt cannot be empty")
 
         model_kwargs = model_kwargs or {}
+        logger = logging.getLogger(__name__)
 
         try:
             response = self.client.chat.completions.create(
@@ -74,7 +77,20 @@ class OpenAIModel(LLMJudgeModel):
                 messages=[{"role": "user", "content": prompt}],
                 **model_kwargs,
             )
-            return response.choices[0].message.content
+
+            # Extract token usage
+            metadata = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+            if hasattr(response, "usage") and response.usage:
+                metadata["input_tokens"] = getattr(response.usage, "prompt_tokens", 0)
+                metadata["output_tokens"] = getattr(response.usage, "completion_tokens", 0)
+                metadata["total_tokens"] = getattr(response.usage, "total_tokens", 0)
+            else:
+                logger.warning("Token usage not available from OpenAI response")
+
+            return {
+                "response": response.choices[0].message.content,
+                "metadata": metadata
+            }
         except openai.RateLimitError:
             raise
         except openai.APIConnectionError:
@@ -85,7 +101,26 @@ class OpenAIModel(LLMJudgeModel):
             raise Exception(f"Unexpected error: {str(e)}") from e
 
     def parse(self, prompt: str, response_format: BaseModel, model_kwargs=None):
+        """
+        Parse structured output from an OpenAI model according to a Pydantic schema.
+
+        Args:
+            prompt (str): The input prompt
+            response_format (BaseModel): Pydantic model defining the expected response structure
+            model_kwargs (dict, optional): Additional kwargs for the API call
+
+        Returns:
+            dict: Dictionary containing:
+                - response (BaseModel): Parsed response matching the response_format schema
+                - metadata (dict): Token usage information with input_tokens, output_tokens, total_tokens
+
+        Raises:
+            ValueError: If prompt is invalid
+            openai.APIError: If there's an API-related error
+        """
         model_kwargs = model_kwargs or {}
+        logger = logging.getLogger(__name__)
+
         completion = self.client.beta.chat.completions.parse(
             model=self.model_name,
             messages=[
@@ -99,8 +134,20 @@ class OpenAIModel(LLMJudgeModel):
             **model_kwargs,
         )
 
+        # Extract token usage
+        metadata = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+        if hasattr(completion, "usage") and completion.usage:
+            metadata["input_tokens"] = getattr(completion.usage, "prompt_tokens", 0)
+            metadata["output_tokens"] = getattr(completion.usage, "completion_tokens", 0)
+            metadata["total_tokens"] = getattr(completion.usage, "total_tokens", 0)
+        else:
+            logger.warning("Token usage not available from OpenAI parse response")
+
         message = completion.choices[0].message
-        return message.parsed
+        return {
+            "response": message.parsed,
+            "metadata": metadata
+        }
 
 
 class GeminiModel(LLMJudgeModel):
@@ -126,7 +173,7 @@ class GeminiModel(LLMJudgeModel):
         stop=stop_after_attempt(3),
         wait=wait_exponential(multiplier=1, min=1, max=10),
     )
-    def call(self, prompt: str, model_kwargs=None) -> str:
+    def call(self, prompt: str, model_kwargs=None) -> dict:
         """
         Call the Gemini API model with the given prompt.
 
@@ -135,7 +182,9 @@ class GeminiModel(LLMJudgeModel):
             model_kwargs (dict, optional): Additional kwargs for the API call
 
         Returns:
-            str: The model's response text
+            dict: Dictionary containing:
+                - response (str): The model's response text
+                - metadata (dict): Token usage and model information
 
         Raises:
             ValueError: If the prompt is empty or model_kwargs is invalid
@@ -146,12 +195,26 @@ class GeminiModel(LLMJudgeModel):
 
         model_kwargs = model_kwargs or {}
         model_kwargs = self._remove_invalid_kwargs(model_kwargs)
+        logger = logging.getLogger(__name__)
 
         try:
             response = self.client.models.generate_content(
                 model=self.model_name, contents=prompt, config=model_kwargs
             )
-            return response.text
+
+            # Extract token usage
+            metadata = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+            if hasattr(response, "usage_metadata") and response.usage_metadata:
+                metadata["input_tokens"] = getattr(response.usage_metadata, "prompt_token_count", 0)
+                metadata["output_tokens"] = getattr(response.usage_metadata, "candidates_token_count", 0)
+                metadata["total_tokens"] = metadata["input_tokens"] + metadata["output_tokens"]
+            else:
+                logger.warning("Token usage not available from Gemini response")
+
+            return {
+                "response": response.text,
+                "metadata": metadata
+            }
         except Exception as e:
             raise Exception(f"Unexpected error: {str(e)}") from e
 
@@ -165,10 +228,14 @@ class GeminiModel(LLMJudgeModel):
             model_kwargs (dict, optional): Additional kwargs for the API call
 
         Returns:
-            The parsed response matching the provided schema
+            dict: Dictionary containing:
+                - response: The parsed response matching the provided schema
+                - metadata (dict): Token usage and model information
         """
         model_kwargs = model_kwargs or {}
         model_kwargs = self._remove_invalid_kwargs(model_kwargs)
+        logger = logging.getLogger(__name__)
+
         config = {
             "response_mime_type": "application/json",
             "response_schema": response_format,
@@ -181,9 +248,21 @@ class GeminiModel(LLMJudgeModel):
             config=config,
         )
 
+        # Extract token usage
+        metadata = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+        if hasattr(response, "usage_metadata") and response.usage_metadata:
+            metadata["input_tokens"] = getattr(response.usage_metadata, "prompt_token_count", 0)
+            metadata["output_tokens"] = getattr(response.usage_metadata, "candidates_token_count", 0)
+            metadata["total_tokens"] = metadata["input_tokens"] + metadata["output_tokens"]
+        else:
+            logger.warning("Token usage not available from Gemini parse response")
+
         response_json = json.loads(response.text)
         parsed_response = TypeAdapter(response_format).validate_python(response_json)
-        return parsed_response
+        return {
+            "response": parsed_response,
+            "metadata": metadata
+        }
 
 
 class AnthropicModel(LLMJudgeModel):
@@ -238,7 +317,7 @@ class AnthropicModel(LLMJudgeModel):
         stop=stop_after_attempt(3),
         wait=wait_exponential(multiplier=1, min=1, max=10),
     )
-    def call(self, prompt: str, model_kwargs=None) -> str:
+    def call(self, prompt: str, model_kwargs=None) -> dict:
         """
         Call the Anthropic API model with the given prompt.
 
@@ -247,7 +326,9 @@ class AnthropicModel(LLMJudgeModel):
             model_kwargs (dict, optional): Additional kwargs for the API call
 
         Returns:
-            str: The model's response text
+            dict: Dictionary containing:
+                - response (str): The model's response text
+                - metadata (dict): Token usage and model information
 
         Raises:
             ValueError: If the prompt is empty or model_kwargs is invalid
@@ -261,6 +342,7 @@ class AnthropicModel(LLMJudgeModel):
 
         model_kwargs = model_kwargs or {}
         model_kwargs = self._remove_invalid_kwargs(model_kwargs)
+        logger = logging.getLogger(__name__)
 
         try:
             max_tokens = None
@@ -275,7 +357,20 @@ class AnthropicModel(LLMJudgeModel):
                 max_tokens=max_tokens,
                 **model_kwargs,
             )
-            return response.content[0].text
+
+            # Extract token usage
+            metadata = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+            if hasattr(response, "usage") and response.usage:
+                metadata["input_tokens"] = getattr(response.usage, "input_tokens", 0)
+                metadata["output_tokens"] = getattr(response.usage, "output_tokens", 0)
+                metadata["total_tokens"] = metadata["input_tokens"] + metadata["output_tokens"]
+            else:
+                logger.warning("Token usage not available from Anthropic response")
+
+            return {
+                "response": response.content[0].text,
+                "metadata": metadata
+            }
         except anthropic.InternalServerError:
             raise
         except anthropic.APITimeoutError:
@@ -295,7 +390,9 @@ class AnthropicModel(LLMJudgeModel):
             model_kwargs (dict, optional): Additional kwargs for the API call
 
         Returns:
-            str: The parsed response matching the provided schema
+            dict: Dictionary containing:
+                - response: The parsed response matching the provided schema
+                - metadata (dict): Token usage and model information
         """
         model_kwargs = model_kwargs or {}
         model_kwargs = self._remove_invalid_kwargs(model_kwargs)
@@ -321,6 +418,16 @@ Return only the JSON object, no other text."""
             **model_kwargs,
         )
 
+        # Extract token usage
+        logger = logging.getLogger(__name__)
+        metadata = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+        if hasattr(response, "usage") and response.usage:
+            metadata["input_tokens"] = getattr(response.usage, "input_tokens", 0)
+            metadata["output_tokens"] = getattr(response.usage, "output_tokens", 0)
+            metadata["total_tokens"] = metadata["input_tokens"] + metadata["output_tokens"]
+        else:
+            logger.warning("Token usage not available from Anthropic parse response")
+
         # Validate response structure before parsing
         if not response.content:
             raise ValueError(
@@ -331,7 +438,6 @@ Return only the JSON object, no other text."""
         response_text = response.content[0].text
 
         # Debug logging to capture what Claude actually returned
-        logger = logging.getLogger(__name__)
         logger.info(f"Anthropic response length: {len(response_text)} chars")
         logger.info(f"Anthropic response (first 500 chars): {response_text[:500]}")
 
@@ -369,7 +475,10 @@ Return only the JSON object, no other text."""
             ) from e
 
         parsed_response = TypeAdapter(response_format).validate_python(response_json)
-        return parsed_response
+        return {
+            "response": parsed_response,
+            "metadata": metadata
+        }
 
 
 class TogetherModel(LLMJudgeModel):
@@ -391,7 +500,7 @@ class TogetherModel(LLMJudgeModel):
         stop=stop_after_attempt(3),
         wait=wait_exponential(multiplier=1, min=1, max=10),
     )
-    def call(self, prompt: str, model_kwargs=None) -> str:
+    def call(self, prompt: str, model_kwargs=None) -> dict:
         """
         Call the Together API model with the given prompt.
 
@@ -400,7 +509,9 @@ class TogetherModel(LLMJudgeModel):
             model_kwargs (dict, optional): Additional kwargs for the API call
 
         Returns:
-            str: The model's response text
+            dict: Dictionary containing:
+                - response (str): The model's response text
+                - metadata (dict): Token usage and model information
 
         Raises:
             ValueError: If the prompt is empty or model_kwargs is invalid
@@ -413,6 +524,7 @@ class TogetherModel(LLMJudgeModel):
             raise ValueError("Prompt cannot be empty")
 
         model_kwargs = model_kwargs or {}
+        logger = logging.getLogger(__name__)
 
         try:
             response = self.client.chat.completions.create(
@@ -420,7 +532,20 @@ class TogetherModel(LLMJudgeModel):
                 messages=[{"role": "user", "content": prompt}],
                 **model_kwargs,
             )
-            return response.choices[0].message.content
+
+            # Extract token usage
+            metadata = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+            if hasattr(response, "usage") and response.usage:
+                metadata["input_tokens"] = getattr(response.usage, "prompt_tokens", 0)
+                metadata["output_tokens"] = getattr(response.usage, "completion_tokens", 0)
+                metadata["total_tokens"] = getattr(response.usage, "total_tokens", 0)
+            else:
+                logger.warning("Token usage not available from Together response")
+
+            return {
+                "response": response.choices[0].message.content,
+                "metadata": metadata
+            }
         except together.error.Timeout:
             raise
         except together.error.APIConnectionError:
@@ -440,9 +565,12 @@ class TogetherModel(LLMJudgeModel):
             model_kwargs (dict, optional): Additional kwargs for the API call
 
         Returns:
-            The parsed response matching the provided schema
+            dict: Dictionary containing:
+                - response: The parsed response matching the provided schema
+                - metadata (dict): Token usage and model information
         """
         model_kwargs = model_kwargs or {}
+        logger = logging.getLogger(__name__)
 
         # Get the raw schema and flatten it to remove $ref constructs (caused by AutoNuggetizer)
         schema = response_format.model_json_schema()
@@ -461,11 +589,23 @@ class TogetherModel(LLMJudgeModel):
                 **model_kwargs,
             )
 
+            # Extract token usage
+            metadata = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+            if hasattr(response, "usage") and response.usage:
+                metadata["input_tokens"] = getattr(response.usage, "prompt_tokens", 0)
+                metadata["output_tokens"] = getattr(response.usage, "completion_tokens", 0)
+                metadata["total_tokens"] = getattr(response.usage, "total_tokens", 0)
+            else:
+                logger.warning("Token usage not available from Together parse response")
+
             response_json = json.loads(response.choices[0].message.content)
             parsed_response = TypeAdapter(response_format).validate_python(
                 response_json
             )
-            return parsed_response
+            return {
+                "response": parsed_response,
+                "metadata": metadata
+            }
         except Exception as e:
             # If grammar validation fails, fall back to prompt-based approach like AnthropicModel
             if "grammar" in str(e).lower():
@@ -479,6 +619,7 @@ class TogetherModel(LLMJudgeModel):
         Fallback parsing method that uses prompt-based JSON generation instead of grammar validation.
         """
         model_kwargs = model_kwargs or {}
+        logger = logging.getLogger(__name__)
         schema = response_format.model_json_schema()
 
         structured_prompt = f"""{prompt}
@@ -493,6 +634,15 @@ Return only the JSON object, no other text."""
             messages=[{"role": "user", "content": structured_prompt}],
             **model_kwargs,
         )
+
+        # Extract token usage
+        metadata = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+        if hasattr(response, "usage") and response.usage:
+            metadata["input_tokens"] = getattr(response.usage, "prompt_tokens", 0)
+            metadata["output_tokens"] = getattr(response.usage, "completion_tokens", 0)
+            metadata["total_tokens"] = getattr(response.usage, "total_tokens", 0)
+        else:
+            logger.warning("Token usage not available from Together fallback parse response")
 
         response_text = response.choices[0].message.content.strip()
 
@@ -516,7 +666,10 @@ Return only the JSON object, no other text."""
             parsed_response = TypeAdapter(response_format).validate_python(
                 response_json
             )
-            return parsed_response
+            return {
+                "response": parsed_response,
+                "metadata": metadata
+            }
         except Exception as e:
             raise ValueError(
                 f"Failed to validate response against schema: {response_json}"

--- a/open_rag_eval/query_generation/llm_generator.py
+++ b/open_rag_eval/query_generation/llm_generator.py
@@ -286,7 +286,8 @@ The text is:
 Your response:
 """
 
-        response = self.model.call(prompt)
+        result = self.model.call(prompt)
+        response = result["response"]
         questions = response.strip().split('\n')
 
         # Clean up questions: remove bullets, numbers, and formatting

--- a/open_rag_eval/run_eval.py
+++ b/open_rag_eval/run_eval.py
@@ -326,7 +326,7 @@ def _print_token_usage_summary(results, evaluator_type: str):
         for metric_name, tokens in metric_tokens.items():
             metric_total = tokens["input"] + tokens["output"]
             if metric_total > 0:
-                percentage = (metric_total / total_tokens * 100) if total_tokens > 0 else 0
+                percentage = metric_total / total_tokens * 100
                 print(f"  {metric_name.upper():12} {metric_total:8,} tokens ({percentage:5.1f}%)")
 
         print("=" * 45 + "\n")

--- a/open_rag_eval/run_eval.py
+++ b/open_rag_eval/run_eval.py
@@ -265,6 +265,73 @@ def _omit_empty_consistency(report: dict) -> dict:
     return {k: v for k, v in report.items() if k != "consistency" or v}
 
 
+def _print_token_usage_summary(results, evaluator_type: str):
+    """
+    Print a summary of token usage across all evaluation results.
+
+    Args:
+        results: List of MultiScoredRAGResult objects
+        evaluator_type: Type of evaluator (e.g., "TREC", "Consistency")
+    """
+    total_input = 0
+    total_output = 0
+    metric_tokens = {
+        "umbrela": {"input": 0, "output": 0},
+        "autonugget": {"input": 0, "output": 0},
+        "citation": {"input": 0, "output": 0},
+        "no_answer": {"input": 0, "output": 0}
+    }
+
+    # Aggregate tokens from all results
+    for multi_scored_result in results:
+        for scored_result in multi_scored_result.scored_rag_results:
+            if not scored_result.scores or not scored_result.scores.generation_score:
+                continue
+
+            token_usage = scored_result.scores.generation_score.scores.get("token_usage", {})
+            if not token_usage:
+                continue
+
+            # Add to total
+            total_input += token_usage.get("total_input_tokens", 0)
+            total_output += token_usage.get("total_output_tokens", 0)
+
+            # Add to metric-specific counts
+            umbrela_tokens = token_usage.get("umbrela_tokens", {})
+            metric_tokens["umbrela"]["input"] += umbrela_tokens.get("input_tokens", 0)
+            metric_tokens["umbrela"]["output"] += umbrela_tokens.get("output_tokens", 0)
+
+            autonugget_tokens = token_usage.get("autonugget_tokens", {})
+            metric_tokens["autonugget"]["input"] += autonugget_tokens.get("input_tokens", 0)
+            metric_tokens["autonugget"]["output"] += autonugget_tokens.get("output_tokens", 0)
+
+            citation_tokens = token_usage.get("citation_tokens", {})
+            metric_tokens["citation"]["input"] += citation_tokens.get("input_tokens", 0)
+            metric_tokens["citation"]["output"] += citation_tokens.get("output_tokens", 0)
+
+            no_answer_tokens = token_usage.get("no_answer_tokens", {})
+            metric_tokens["no_answer"]["input"] += no_answer_tokens.get("input_tokens", 0)
+            metric_tokens["no_answer"]["output"] += no_answer_tokens.get("output_tokens", 0)
+
+    total_tokens = total_input + total_output
+
+    # Print summary if there are tokens to report
+    if total_tokens > 0:
+        print(f"\n=== Token Usage Summary ({evaluator_type}) ===")
+        print(f"Total Input Tokens:  {total_input:,}")
+        print(f"Total Output Tokens: {total_output:,}")
+        print(f"Total Tokens:        {total_tokens:,}")
+        print("\nBreakdown by Metric:")
+
+        for metric_name, tokens in metric_tokens.items():
+            metric_total = tokens["input"] + tokens["output"]
+            if metric_total > 0:
+                percentage = (metric_total / total_tokens * 100) if total_tokens > 0 else 0
+                print(f"  {metric_name.upper():12} {metric_total:8,} tokens ({percentage:5.1f}%)")
+
+        print("=" * 45 + "\n")
+
+
 def run_eval(config_path: str):
     """
     Main function to run the evaluation process.
@@ -344,6 +411,9 @@ def run_eval(config_path: str):
             results_folder, f"{evaluator_type}-{config.eval_results_file}"
         )
         evaluator.to_csv(results, eval_results_path)
+
+        # Print token usage summary
+        _print_token_usage_summary(results, evaluator_type)
 
         # Plot results
         try:

--- a/tests/query_generation/test_llm_generator.py
+++ b/tests/query_generation/test_llm_generator.py
@@ -42,7 +42,10 @@ class TestLLMQueryGenerator(unittest.TestCase):
         )
 
         # Mock the model response
-        self.mock_model.call.return_value = "¿Qué es esto?"
+        self.mock_model.call.return_value = {
+            "response": "¿Qué es esto?",
+            "metadata": {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15}
+        }
 
         # Generate questions
         generator.generate(documents=["Test document"], n_questions=1)
@@ -73,9 +76,12 @@ class TestLLMQueryGenerator(unittest.TestCase):
     def test_generate_with_valid_response(self):
         """Test successful query generation."""
         # Mock LLM response
-        self.mock_model.call.return_value = """What is machine learning?
+        self.mock_model.call.return_value = {
+            "response": """What is machine learning?
 How does neural network work?
-Why is deep learning important?"""
+Why is deep learning important?""",
+            "metadata": {"input_tokens": 10, "output_tokens": 20, "total_tokens": 30}
+        }
 
         documents = ["Machine learning is a subset of AI."]
         queries = self.generator.generate(
@@ -96,9 +102,12 @@ Why is deep learning important?"""
     def test_generate_filters_by_word_count(self):
         """Test that queries are filtered by word count."""
         # Mock LLM response with mixed word counts
-        self.mock_model.call.return_value = """What?
+        self.mock_model.call.return_value = {
+            "response": """What?
 What is this?
-What is this long question about machine learning?"""
+What is this long question about machine learning?""",
+            "metadata": {"input_tokens": 10, "output_tokens": 15, "total_tokens": 25}
+        }
 
         documents = ["Test document"]
         queries = self.generator.generate(
@@ -117,9 +126,12 @@ What is this long question about machine learning?"""
     def test_generate_deduplicates_questions(self):
         """Test that duplicate questions are removed."""
         # Mock LLM response with duplicates
-        self.mock_model.call.return_value = """What is AI?
+        self.mock_model.call.return_value = {
+            "response": """What is AI?
 What is AI?
-How does AI work?"""
+How does AI work?""",
+            "metadata": {"input_tokens": 10, "output_tokens": 10, "total_tokens": 20}
+        }
 
         documents = ["AI is artificial intelligence."]
         queries = self.generator.generate(
@@ -151,9 +163,12 @@ How does AI work?"""
     def test_generate_cleans_question_formatting(self):
         """Test that questions are cleaned of bullets, numbers, etc."""
         # Mock LLM response with formatting
-        self.mock_model.call.return_value = """- What is AI?
+        self.mock_model.call.return_value = {
+            "response": """- What is AI?
 * How does ML work?
-1. Why use deep learning?"""
+1. Why use deep learning?""",
+            "metadata": {"input_tokens": 10, "output_tokens": 15, "total_tokens": 25}
+        }
 
         documents = ["Test document"]
         queries = self.generator.generate(
@@ -247,7 +262,10 @@ How does AI work?"""
         )
 
         # Mock response
-        self.mock_model.call.return_value = "What is this?"
+        self.mock_model.call.return_value = {
+            "response": "What is this?",
+            "metadata": {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15}
+        }
 
         # Generate questions
         generator.generate(documents=["Test document"], n_questions=1)
@@ -327,7 +345,10 @@ How does AI work?"""
         )
 
         # Mock response
-        self.mock_model.call.return_value = "What is this?"
+        self.mock_model.call.return_value = {
+            "response": "What is this?",
+            "metadata": {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15}
+        }
 
         # Generate questions
         generator.generate(documents=["Test document"], n_questions=1)

--- a/tests/test_anthropic_markdown_stripping.py
+++ b/tests/test_anthropic_markdown_stripping.py
@@ -100,15 +100,20 @@ class TestAnthropicMarkdownStripping(unittest.TestCase):
 }
 ```'''
         mock_response.content = [mock_content]
+        # Mock usage for token tracking
+        mock_response.usage = Mock(input_tokens=100, output_tokens=50)
         mock_client.messages.create.return_value = mock_response
 
         # Create model and call parse
         model = AnthropicModel({"name": "claude-sonnet-4-5", "api_key": "test-key"})
         result = model.parse("test prompt", TestResponse, {"temperature": 0.0})
 
-        # Verify the result
-        self.assertIsInstance(result, TestResponse)
-        self.assertEqual(result.score, "2")
+        # Verify the result - parse returns {"response": ..., "metadata": ...}
+        self.assertIsInstance(result["response"], TestResponse)
+        self.assertEqual(result["response"].score, "2")
+        self.assertEqual(result["metadata"]["input_tokens"], 100)
+        self.assertEqual(result["metadata"]["output_tokens"], 50)
+        self.assertEqual(result["metadata"]["total_tokens"], 150)
 
     @patch('open_rag_eval.models.llm_judges.anthropic.Anthropic')
     def test_anthropic_model_with_plain_json_response(self, mock_anthropic_class):
@@ -125,15 +130,18 @@ class TestAnthropicMarkdownStripping(unittest.TestCase):
         mock_content = Mock()
         mock_content.text = '{"score": "3"}'
         mock_response.content = [mock_content]
+        # Mock usage for token tracking
+        mock_response.usage = Mock(input_tokens=80, output_tokens=20)
         mock_client.messages.create.return_value = mock_response
 
         # Create model and call parse
         model = AnthropicModel({"name": "claude-sonnet-4-5", "api_key": "test-key"})
         result = model.parse("test prompt", TestResponse, {"temperature": 0.0})
 
-        # Verify the result
-        self.assertIsInstance(result, TestResponse)
-        self.assertEqual(result.score, "3")
+        # Verify the result - parse returns {"response": ..., "metadata": ...}
+        self.assertIsInstance(result["response"], TestResponse)
+        self.assertEqual(result["response"].score, "3")
+        self.assertEqual(result["metadata"]["total_tokens"], 100)
 
 
 if __name__ == "__main__":

--- a/tests/test_autonugget_metric.py
+++ b/tests/test_autonugget_metric.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import MagicMock, Mock
+from unittest.mock import MagicMock
 
 from open_rag_eval.metrics.autonugget_metric import (
     AutoNuggetMetric,
@@ -23,43 +23,53 @@ class TestAutoNuggetMetric(unittest.TestCase):
         retrieved_passages = {"1": "passage one", "2": "passage two", "3": "passage 3"}
         umbrela_scores = {"1": 2, "2": 1 ,"3": 0}
 
-        mock_response = Mock()
         mock_response = Nuggets(nuggets=["nugget1", "nugget2"])
-        self.model.parse.return_value = mock_response
+        self.model.parse.return_value = {
+            "response": mock_response,
+            "metadata": {"input_tokens": 100, "output_tokens": 50, "total_tokens": 150}
+        }
 
-        nuggets = self.metric._create_nuggets(query, retrieved_passages, umbrela_scores)
+        nuggets, token_usage = self.metric._create_nuggets(query, retrieved_passages, umbrela_scores)
         self.assertEqual(nuggets, ["nugget1", "nugget2"])
+        # 5 iterations (default nugget_creation_iters) * 150 tokens each = 750
+        self.assertEqual(token_usage["total_tokens"], 750)
 
     def test_score_and_sort_nuggets(self):
         query = "test query"
         nuggets = ["nugget1", "nugget2", "nugget3"]
 
-        mock_response = Mock()
         mock_response = NuggetImportance(importance=[
             NuggetImportanceValues.VITAL,
             NuggetImportanceValues.OKAY,
             NuggetImportanceValues.VITAL
         ])
-        self.model.parse.return_value = mock_response
+        self.model.parse.return_value = {
+            "response": mock_response,
+            "metadata": {"input_tokens": 100, "output_tokens": 50, "total_tokens": 150}
+        }
 
-        sorted_nuggets, sorted_labels = self.metric._score_and_sort_nuggets(query, nuggets)
+        (sorted_nuggets, sorted_labels), token_usage = self.metric._score_and_sort_nuggets(query, nuggets)
         self.assertEqual(sorted_nuggets, ["nugget1", "nugget3", "nugget2"])
         self.assertEqual(sorted_labels, ["vital", "vital", "okay"])
+        self.assertEqual(token_usage["total_tokens"], 150)
 
     def test_assign_nuggets(self):
         query = "test query"
         generated_answer = [GeneratedAnswerPart(text="generated passage", citations=["1"])]
         nuggets = ["nugget1", "nugget2"]
 
-        mock_response = Mock()
         mock_response = NuggetAssignment(assignment=[
             NuggetAssignmentValues.SUPPORT,
             NuggetAssignmentValues.PARTIAL_SUPPORT
         ])
-        self.model.parse.return_value = mock_response
+        self.model.parse.return_value = {
+            "response": mock_response,
+            "metadata": {"input_tokens": 100, "output_tokens": 50, "total_tokens": 150}
+        }
 
-        assignments = self.metric._assign_nuggets(query, generated_answer, nuggets)
+        assignments, token_usage = self.metric._assign_nuggets(query, generated_answer, nuggets)
         self.assertEqual(assignments, ["support", "partial_support"])
+        self.assertEqual(token_usage["total_tokens"], 150)
 
     def test_evaluate_answer(self):
         nuggets = ["nugget1", "nugget2"]

--- a/tests/test_llm_judges_integration.py
+++ b/tests/test_llm_judges_integration.py
@@ -128,13 +128,30 @@ class TestLLMJudgesIntegration(unittest.TestCase):
             self.skipTest("OpenAI API key not configured")
 
         prompt = "What is 2+2? Answer with just the number."
-        response = self.openai_model.call(prompt)
+        result = self.openai_model.call(prompt)
 
-        # Basic validation of response
+        # Validate result structure
+        self.assertIsInstance(result, dict)
+        self.assertIn("response", result)
+        self.assertIn("metadata", result)
+
+        # Validate response content
+        response = result["response"]
         self.assertIsInstance(response, str)
         self.assertTrue(len(response.strip()) > 0)
         # The response should contain 4 somewhere
         self.assertIn("4", response)
+
+        # Validate token metadata
+        metadata = result["metadata"]
+        self.assertIsInstance(metadata, dict)
+        self.assertIn("input_tokens", metadata)
+        self.assertIn("output_tokens", metadata)
+        self.assertIn("total_tokens", metadata)
+        self.assertGreater(metadata["input_tokens"], 0)
+        self.assertGreater(metadata["output_tokens"], 0)
+        self.assertEqual(metadata["total_tokens"],
+                        metadata["input_tokens"] + metadata["output_tokens"])
 
     def test_gemini_integration(self):
         """Test Gemini model with actual API calls"""
@@ -142,13 +159,26 @@ class TestLLMJudgesIntegration(unittest.TestCase):
             self.skipTest("Gemini API key not configured")
 
         prompt = "What is 2+2? Answer with just the number."
-        response = self.gemini_model.call(prompt)
+        result = self.gemini_model.call(prompt)
 
-        # Basic validation of response
+        # Validate result structure
+        self.assertIsInstance(result, dict)
+        self.assertIn("response", result)
+        self.assertIn("metadata", result)
+
+        # Validate response content
+        response = result["response"]
         self.assertIsInstance(response, str)
         self.assertTrue(len(response.strip()) > 0)
         # The response should contain 4 somewhere
         self.assertIn("4", response)
+
+        # Validate token metadata
+        metadata = result["metadata"]
+        self.assertIsInstance(metadata, dict)
+        self.assertIn("input_tokens", metadata)
+        self.assertIn("output_tokens", metadata)
+        self.assertIn("total_tokens", metadata)
 
     def test_anthropic_integration(self):
         """Test Anthropic model with actual API calls"""
@@ -156,13 +186,26 @@ class TestLLMJudgesIntegration(unittest.TestCase):
             self.skipTest("Anthropic API key not configured")
 
         prompt = "What is 2+2? Answer with just the number."
-        response = self.anthropic_model.call(prompt)
+        result = self.anthropic_model.call(prompt)
 
-        # Basic validation of response
+        # Validate result structure
+        self.assertIsInstance(result, dict)
+        self.assertIn("response", result)
+        self.assertIn("metadata", result)
+
+        # Validate response content
+        response = result["response"]
         self.assertIsInstance(response, str)
         self.assertTrue(len(response.strip()) > 0)
         # The response should contain 4 somewhere
         self.assertIn("4", response)
+
+        # Validate token metadata
+        metadata = result["metadata"]
+        self.assertIsInstance(metadata, dict)
+        self.assertIn("input_tokens", metadata)
+        self.assertIn("output_tokens", metadata)
+        self.assertIn("total_tokens", metadata)
 
     def test_together_integration(self):
         """Test Together model with actual API calls"""
@@ -170,13 +213,26 @@ class TestLLMJudgesIntegration(unittest.TestCase):
             self.skipTest("Together API key not configured")
 
         prompt = "What is 2+2? Answer with just the number."
-        response = self.together_model.call(prompt)
+        result = self.together_model.call(prompt)
 
-        # Basic validation of response
+        # Validate result structure
+        self.assertIsInstance(result, dict)
+        self.assertIn("response", result)
+        self.assertIn("metadata", result)
+
+        # Validate response content
+        response = result["response"]
         self.assertIsInstance(response, str)
         self.assertTrue(len(response.strip()) > 0)
         # The response should contain 4 somewhere
         self.assertIn("4", response)
+
+        # Validate token metadata
+        metadata = result["metadata"]
+        self.assertIsInstance(metadata, dict)
+        self.assertIn("input_tokens", metadata)
+        self.assertIn("output_tokens", metadata)
+        self.assertIn("total_tokens", metadata)
 
     def test_openai_parse_integration(self):
         """Test OpenAI model parse method with actual API calls"""
@@ -189,11 +245,25 @@ class TestLLMJudgesIntegration(unittest.TestCase):
             statement=statement, citation=citation
         )
 
-        response = self.openai_model.parse(prompt, CitationSupport, self.model_kwargs)
+        result = self.openai_model.parse(prompt, CitationSupport, self.model_kwargs)
 
+        # Validate result structure
+        self.assertIsInstance(result, dict)
+        self.assertIn("response", result)
+        self.assertIn("metadata", result)
+
+        # Validate response content
+        response = result["response"]
         self.assertIsInstance(response, CitationSupport)
         self.assertIsInstance(response.support, CitationSupportValues)
         self.assertIn(response.support, CitationSupportValues)
+
+        # Validate token metadata
+        metadata = result["metadata"]
+        self.assertIsInstance(metadata, dict)
+        self.assertIn("input_tokens", metadata)
+        self.assertIn("output_tokens", metadata)
+        self.assertIn("total_tokens", metadata)
 
     def test_gemini_parse_integration(self):
         """Test Gemini model parse method with actual API calls"""
@@ -206,11 +276,25 @@ class TestLLMJudgesIntegration(unittest.TestCase):
             statement=statement, citation=citation
         )
 
-        response = self.gemini_model.parse(prompt, CitationSupport, self.model_kwargs)
+        result = self.gemini_model.parse(prompt, CitationSupport, self.model_kwargs)
 
+        # Validate result structure
+        self.assertIsInstance(result, dict)
+        self.assertIn("response", result)
+        self.assertIn("metadata", result)
+
+        # Validate response content
+        response = result["response"]
         self.assertIsInstance(response, CitationSupport)
         self.assertIsInstance(response.support, CitationSupportValues)
         self.assertIn(response.support, CitationSupportValues)
+
+        # Validate token metadata
+        metadata = result["metadata"]
+        self.assertIsInstance(metadata, dict)
+        self.assertIn("input_tokens", metadata)
+        self.assertIn("output_tokens", metadata)
+        self.assertIn("total_tokens", metadata)
 
     def test_anthropic_parse_integration(self):
         """Test Anthropic model parse method with actual API calls"""
@@ -223,11 +307,25 @@ class TestLLMJudgesIntegration(unittest.TestCase):
             statement=statement, citation=citation
         )
 
-        response = self.anthropic_model.parse(prompt, CitationSupport, self.model_kwargs)
+        result = self.anthropic_model.parse(prompt, CitationSupport, self.model_kwargs)
 
+        # Validate result structure
+        self.assertIsInstance(result, dict)
+        self.assertIn("response", result)
+        self.assertIn("metadata", result)
+
+        # Validate response content
+        response = result["response"]
         self.assertIsInstance(response, CitationSupport)
         self.assertIsInstance(response.support, CitationSupportValues)
         self.assertIn(response.support, CitationSupportValues)
+
+        # Validate token metadata
+        metadata = result["metadata"]
+        self.assertIsInstance(metadata, dict)
+        self.assertIn("input_tokens", metadata)
+        self.assertIn("output_tokens", metadata)
+        self.assertIn("total_tokens", metadata)
 
     def test_together_parse_integration(self):
         """Test Together model parse method with actual API calls"""
@@ -240,11 +338,25 @@ class TestLLMJudgesIntegration(unittest.TestCase):
             statement=statement, citation=citation
         )
 
-        response = self.together_model.parse(prompt, CitationSupport, self.model_kwargs)
+        result = self.together_model.parse(prompt, CitationSupport, self.model_kwargs)
 
+        # Validate result structure
+        self.assertIsInstance(result, dict)
+        self.assertIn("response", result)
+        self.assertIn("metadata", result)
+
+        # Validate response content
+        response = result["response"]
         self.assertIsInstance(response, CitationSupport)
         self.assertIsInstance(response.support, CitationSupportValues)
         self.assertIn(response.support, CitationSupportValues)
+
+        # Validate token metadata
+        metadata = result["metadata"]
+        self.assertIsInstance(metadata, dict)
+        self.assertIn("input_tokens", metadata)
+        self.assertIn("output_tokens", metadata)
+        self.assertIn("total_tokens", metadata)
 
 
 if __name__ == "__main__":

--- a/tests/test_llm_judges_integration.py
+++ b/tests/test_llm_judges_integration.py
@@ -151,7 +151,7 @@ class TestLLMJudgesIntegration(unittest.TestCase):
         self.assertGreater(metadata["input_tokens"], 0)
         self.assertGreater(metadata["output_tokens"], 0)
         self.assertEqual(metadata["total_tokens"],
-                        metadata["input_tokens"] + metadata["output_tokens"])
+                         metadata["input_tokens"] + metadata["output_tokens"])
 
     def test_gemini_integration(self):
         """Test Gemini model with actual API calls"""

--- a/tests/test_no_answer_metric.py
+++ b/tests/test_no_answer_metric.py
@@ -21,9 +21,10 @@ class TestNoAnswerMetric(unittest.TestCase):
         # Setup
         query = "What is the capital of France?"
         answer = "I don't have enough information to answer this question."
-        self.mock_model.parse.return_value = QueryAnswered(
-            answered=QueryAnsweredValues.NO
-        )
+        self.mock_model.parse.return_value = {
+            "response": QueryAnswered(answered=QueryAnsweredValues.NO),
+            "metadata": {"input_tokens": 100, "output_tokens": 50, "total_tokens": 150}
+        }
 
         result = AugmentedGenerationResult(
             query=query,
@@ -37,14 +38,16 @@ class TestNoAnswerMetric(unittest.TestCase):
 
         # Assert
         self.assertEqual(scores["query_answered"], "no")
+        self.assertEqual(scores["token_usage"]["total_tokens"], 150)
         self.mock_model.parse.assert_called_once()
 
     def test_compute_positive_answer(self):
         # Setup
         query = "What is the capital of France?"
-        self.mock_model.parse.return_value = QueryAnswered(
-            answered=QueryAnsweredValues.YES
-        )
+        self.mock_model.parse.return_value = {
+            "response": QueryAnswered(answered=QueryAnsweredValues.YES),
+            "metadata": {"input_tokens": 80, "output_tokens": 20, "total_tokens": 100}
+        }
 
         result = AugmentedGenerationResult(
             query=query,
@@ -63,6 +66,7 @@ class TestNoAnswerMetric(unittest.TestCase):
 
         # Assert
         self.assertEqual(scores["query_answered"], "yes")
+        self.assertEqual(scores["token_usage"]["total_tokens"], 100)
         self.mock_model.parse.assert_called_once()
 
     def test_compute_model_error(self):

--- a/tests/test_umbrela_metric.py
+++ b/tests/test_umbrela_metric.py
@@ -20,8 +20,14 @@ class TestUMBRELAMetric(unittest.TestCase):
         passages = {"1": "passage 1", "2": "passage 2"}
         retrieval_result = RetrievalResult(query=query, retrieved_passages=passages)
 
-        mock_response1 = Mock(score=Mock(value="3"))
-        mock_response2 = Mock(score=Mock(value="2"))
+        mock_response1 = {
+            "response": Mock(score=Mock(value="3")),
+            "metadata": {"input_tokens": 100, "output_tokens": 50, "total_tokens": 150}
+        }
+        mock_response2 = {
+            "response": Mock(score=Mock(value="2")),
+            "metadata": {"input_tokens": 100, "output_tokens": 50, "total_tokens": 150}
+        }
         self.model.parse.side_effect = [mock_response1, mock_response2]
 
         scores = self.metric.compute(retrieval_result, self.k_values)
@@ -29,6 +35,7 @@ class TestUMBRELAMetric(unittest.TestCase):
         expected_umbrela_scores = {"1": 3, "2": 2}
         self.assertEqual(scores["umbrela_scores"], expected_umbrela_scores)
         self.assertIn("retrieval_scores", scores)
+        self.assertEqual(scores["token_usage"]["total_tokens"], 300)
         self.assertEqual(self.model.parse.call_count, 2)
 
     def test_compute_empty_passages(self):
@@ -60,7 +67,10 @@ class TestUMBRELAMetric(unittest.TestCase):
         passages = {"1": "passage 1"}
         retrieval_result = RetrievalResult(query=query, retrieved_passages=passages)
 
-        mock_response = Mock(score=None, refusal="Refused to score")
+        mock_response = {
+            "response": Mock(score=None, refusal="Refused to score"),
+            "metadata": {"input_tokens": 100, "output_tokens": 50, "total_tokens": 150}
+        }
         self.model.parse.return_value = mock_response
 
         with self.assertRaises(Exception) as context:


### PR DESCRIPTION
## Summary

- Adds comprehensive token usage tracking for all LLM judge models (OpenAI, Gemini, Anthropic)
- All metrics (UMBRELA, AutoNugget, Citation, NoAnswer) now track and return token consumption
- TRECEvaluator aggregates token usage from all metrics and exports to CSV
- Bumps version to 0.3.0 (minor API change: `call()` and `parse()` now return dict with response + metadata)

## Changes

**LLM Judges** (`models/llm_judges.py`):
- `call()` and `parse()` methods now return `{"response": ..., "metadata": {"input_tokens", "output_tokens", "total_tokens"}}`
- Applies to OpenAIModel, GeminiModel, and AnthropicModel

**Metrics**:
- `umbrela_metric.py`: Tracks tokens across all passage evaluations
- `autonugget_metric.py`: Tracks tokens across nugget creation, scoring, and assignment steps
- `citation_metric.py`: Tracks tokens across all citation support checks
- `no_answer_metric.py`: Tracks tokens for answer detection

**Evaluator** (`trec_evaluator.py`):
- Aggregates token usage from all metrics per query
- Adds `total_input_tokens`, `total_output_tokens`, `total_tokens` columns to CSV output

## Test plan

- [ ] Verify existing tests pass with updated API
- [ ] Confirm token usage appears in evaluation output CSV
- [ ] Test with each LLM provider (OpenAI, Gemini, Anthropic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)