### PR TITLE
Add chunking-strategy comparison layer to the RAG eval pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,6 +539,39 @@ evaluator:
 - You can use TRECEvaluator alone for queries without golden answers, and GoldenAnswerEvaluator will only evaluate those that have them
 - See `config_examples/eval_config_trec_golden_combined.yaml` for a complete example
 
+## Comparing Chunking Strategies
+
+When you index your own documents (using the `LangChainConnector` or `LlamaIndexConnector`), the chunk size and overlap used during indexing have a large impact on retrieval and answer quality. Open RAG Eval can compare multiple chunking strategies for you and report the best-performing one.
+
+Add an optional `chunking` block to your eval config listing the strategies to compare:
+
+```yaml
+connector:
+  type: "LangChainConnector"   # or "LlamaIndexConnector"
+  options:
+    folder: /path/to/folder-with-files/
+    top_k: 10
+
+chunking:
+  strategies:
+    - { name: small,  chunk_size: 256,  chunk_overlap: 32 }
+    - { name: medium, chunk_size: 512,  chunk_overlap: 64 }
+    - { name: large,  chunk_size: 1024, chunk_overlap: 128 }
+```
+
+When a `chunking` block is present, the pipeline re-indexes the documents once per strategy, runs the configured evaluators on each, and then ranks the strategies by **mean UMBRELA retrieval score**. It produces, in your `results_folder`:
+
+- `answers_<name>.csv` and `TRECEvaluator-<name>-results.csv` for each strategy
+- `chunking_comparison.png` — grouped boxplots comparing the strategies (one box per strategy)
+- `chunking_comparison.json` — the ranked strategies plus the `best_strategy`
+- a ranked summary printed to the console, highlighting the winning strategy
+
+Notes:
+
+- Chunking comparison only applies to connectors that control document chunking (`LangChainConnector`, `LlamaIndexConnector`). It is ignored (with a warning) for connectors such as the Vectara connector, which return pre-chunked passages.
+- If no `chunking` block is present, evaluation runs exactly as before.
+- See `config_examples/eval_config_chunking_comparison.yaml` for a complete example.
+
 # How does open-rag-eval work?
 
 ## Evaluation Workflow

--- a/config_examples/eval_config_chunking_comparison.yaml
+++ b/config_examples/eval_config_chunking_comparison.yaml
@@ -1,0 +1,46 @@
+
+input_queries: "queries.csv"  # file with a list of queries to use for evaluation
+
+# Evaluation results are written to the "results_folder" folder.
+# You can override the names of files in this folder by specifying 'generated_answers', 'eval_results_file', and 'metrics_file'.
+results_folder: "results/"
+generated_answers: "answers.csv"
+eval_results_file: "results.csv"
+metrics_file: "metrics.png"
+
+evaluator:
+  - type: "TRECEvaluator"
+    model:
+      type: "OpenAIModel"
+      name: "gpt-4o-mini"
+      api_key: ${oc.env:OPENAI_API_KEY}  # Reads from environment variable.
+    options:
+      # The k values to evaluate metrics like precision@k at.
+      k_values: [1, 3, 5]
+      run_consistency: True
+      metrics_to_run_consistency: ["mean_umbrela_score","vital_nuggetizer_score", "citation_f1_score" ]
+
+connector:
+  type: "LangChainConnector"  # also supported: "LlamaIndexConnector"
+  options:
+    # the folder with the files to be indexed.
+    # all files in this folder and any subfolders will be indexed.
+    folder: /path/to/folder-with-files/
+    top_k: 10
+    max_workers: -1  # -1 to use all available CPU cores for parallel processing.
+    repeat_query: 1
+
+# Optional chunking-comparison layer.
+# When present (and the connector controls document chunking, i.e. LangChain or
+# LlamaIndex), the pipeline re-indexes the documents once per strategy below,
+# evaluates each, and reports the best-performing strategy (ranked by mean
+# UMBRELA retrieval score). It produces:
+#   - results/answers_<name>.csv and results/TRECEvaluator-<name>-results.csv per strategy
+#   - results/chunking_comparison.png  (grouped boxplots, one box per strategy)
+#   - results/chunking_comparison.json (ranked strategies + best_strategy)
+#   - a ranked summary printed to the console
+chunking:
+  strategies:
+    - { name: small,  chunk_size: 256,  chunk_overlap: 32 }
+    - { name: medium, chunk_size: 512,  chunk_overlap: 64 }
+    - { name: large,  chunk_size: 1024, chunk_overlap: 128 }

--- a/open_rag_eval/chunking/__init__.py
+++ b/open_rag_eval/chunking/__init__.py
@@ -1,0 +1,3 @@
+from .strategy import ChunkingStrategy, parse_chunking_strategies
+
+__all__ = ["ChunkingStrategy", "parse_chunking_strategies"]

--- a/open_rag_eval/chunking/strategy.py
+++ b/open_rag_eval/chunking/strategy.py
@@ -1,0 +1,102 @@
+"""Chunking strategy descriptors for the chunking-comparison layer.
+
+A :class:`ChunkingStrategy` is a small, library-agnostic descriptor of how
+documents should be split into chunks before indexing. Local-document
+connectors (LangChain, LlamaIndex) translate a strategy into their own native
+splitter, so this module deliberately avoids importing any specific chunking
+library.
+"""
+
+from dataclasses import dataclass
+from typing import Any, List
+
+
+@dataclass
+class ChunkingStrategy:
+    """A named chunking configuration.
+
+    Attributes:
+        name: Human-readable identifier used in output filenames and plot labels.
+        chunk_size: Target chunk size (characters for LangChain's recursive
+            splitter, tokens for LlamaIndex's sentence splitter).
+        chunk_overlap: Overlap between consecutive chunks.
+        splitter: Extension hook selecting the splitter family. Currently only
+            "recursive" is implemented; connectors map it to their native splitter.
+    """
+
+    name: str
+    chunk_size: int = 1000
+    chunk_overlap: int = 200
+    splitter: str = "recursive"
+
+
+def parse_chunking_strategies(chunking_cfg: Any) -> List[ChunkingStrategy]:
+    """Parse the ``chunking`` config block into a list of strategies.
+
+    Args:
+        chunking_cfg: The ``chunking`` mapping from the eval config. May be an
+            OmegaConf node or a plain dict. Must contain a non-empty
+            ``strategies`` list.
+
+    Returns:
+        A list of validated :class:`ChunkingStrategy` instances.
+
+    Raises:
+        ValueError: If no strategies are provided, a strategy is missing a name,
+            strategy names are not unique, or ``chunk_overlap >= chunk_size``.
+    """
+    if chunking_cfg is None:
+        raise ValueError("Chunking config is empty.")
+
+    # Support both dict-like configs (OmegaConf DictConfig, dict) uniformly.
+    strategies_cfg = (
+        chunking_cfg.get("strategies")
+        if hasattr(chunking_cfg, "get")
+        else getattr(chunking_cfg, "strategies", None)
+    )
+    if not strategies_cfg:
+        raise ValueError(
+            "Chunking config must contain a non-empty 'strategies' list."
+        )
+
+    strategies: List[ChunkingStrategy] = []
+    seen_names = set()
+    for idx, item in enumerate(strategies_cfg):
+        getter = item.get if hasattr(item, "get") else (lambda k, d=None: getattr(item, k, d))
+
+        name = getter("name", None)
+        if not name:
+            raise ValueError(f"Chunking strategy at index {idx} is missing a 'name'.")
+        name = str(name)
+        if name in seen_names:
+            raise ValueError(f"Duplicate chunking strategy name: '{name}'.")
+        seen_names.add(name)
+
+        chunk_size = int(getter("chunk_size", 1000))
+        chunk_overlap = int(getter("chunk_overlap", 200))
+        splitter = str(getter("splitter", "recursive"))
+
+        if chunk_size <= 0:
+            raise ValueError(
+                f"Chunking strategy '{name}' has non-positive chunk_size: {chunk_size}."
+            )
+        if chunk_overlap < 0:
+            raise ValueError(
+                f"Chunking strategy '{name}' has negative chunk_overlap: {chunk_overlap}."
+            )
+        if chunk_overlap >= chunk_size:
+            raise ValueError(
+                f"Chunking strategy '{name}' has chunk_overlap ({chunk_overlap}) "
+                f">= chunk_size ({chunk_size})."
+            )
+
+        strategies.append(
+            ChunkingStrategy(
+                name=name,
+                chunk_size=chunk_size,
+                chunk_overlap=chunk_overlap,
+                splitter=splitter,
+            )
+        )
+
+    return strategies

--- a/open_rag_eval/chunking_comparison.py
+++ b/open_rag_eval/chunking_comparison.py
@@ -63,10 +63,17 @@ def _mean_metric(results_file: Optional[str], metric: str) -> Optional[float]:
     except Exception as e:  # pragma: no cover - defensive
         logger.warning("Failed to read %s for ranking: %s", results_file, e)
         return None
-    if metric not in df.columns:
+    # TRECEvaluator.to_csv writes per-run columns prefixed with "run_1_". Mirror
+    # the resolution used by TRECEvaluator.plot_metrics: prefer the bare metric
+    # name (present in the consolidated CSV), else fall back to the run_1_ form.
+    if metric in df.columns:
+        column = metric
+    elif f"run_1_{metric}" in df.columns:
+        column = f"run_1_{metric}"
+    else:
         logger.warning("Metric '%s' not found in %s.", metric, results_file)
         return None
-    series = pd.to_numeric(df[metric], errors="coerce").dropna()
+    series = pd.to_numeric(df[column], errors="coerce").dropna()
     if series.empty:
         return None
     return float(series.mean())

--- a/open_rag_eval/chunking_comparison.py
+++ b/open_rag_eval/chunking_comparison.py
@@ -1,0 +1,133 @@
+"""Ranking and reporting for the chunking-strategy comparison layer.
+
+After each chunking strategy has been evaluated and written its own
+TRECEvaluator results CSV, these helpers rank the strategies by mean UMBRELA
+retrieval score, write a ``chunking_comparison.json`` report, and print a
+console summary highlighting the best-performing strategy.
+"""
+
+import json
+import logging
+import os
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+# The metric used to decide the best-performing chunking strategy. Chunking
+# primarily affects retrieval quality, so we rank by mean UMBRELA.
+RANKING_METRIC = "retrieval_score_mean_umbrela_score"
+
+COMPARISON_JSON_FILENAME = "chunking_comparison.json"
+COMPARISON_PLOT_FILENAME = "chunking_comparison.png"
+
+
+def rank_strategies(
+    strategy_results: List[Dict[str, Any]],
+    metric: str = RANKING_METRIC,
+) -> List[Dict[str, Any]]:
+    """Rank chunking strategies by the mean of a metric column.
+
+    Args:
+        strategy_results: One dict per strategy, each with keys ``name``,
+            ``chunk_size``, ``chunk_overlap`` and ``results_file`` (path to that
+            strategy's TRECEvaluator results CSV).
+        metric: The CSV column to average per strategy. Defaults to
+            :data:`RANKING_METRIC`.
+
+    Returns:
+        A new list of dicts (copies of the inputs) each augmented with a
+        ``score`` key (mean of the metric column, or ``None`` if unavailable),
+        sorted by ``score`` descending. Strategies whose score could not be
+        computed sort last.
+    """
+    ranked: List[Dict[str, Any]] = []
+    for entry in strategy_results:
+        score = _mean_metric(entry.get("results_file"), metric)
+        ranked.append({**entry, "score": score})
+
+    # Sort by score descending; None scores sort last.
+    ranked.sort(key=lambda e: (e["score"] is not None, e["score"] or 0.0), reverse=True)
+    return ranked
+
+
+def _mean_metric(results_file: Optional[str], metric: str) -> Optional[float]:
+    """Return the mean of `metric` in `results_file`, or None if unavailable."""
+    if not results_file or not os.path.exists(results_file):
+        logger.warning("Results file not found for ranking: %s", results_file)
+        return None
+    try:
+        df = pd.read_csv(results_file)
+    except Exception as e:  # pragma: no cover - defensive
+        logger.warning("Failed to read %s for ranking: %s", results_file, e)
+        return None
+    if metric not in df.columns:
+        logger.warning("Metric '%s' not found in %s.", metric, results_file)
+        return None
+    series = pd.to_numeric(df[metric], errors="coerce").dropna()
+    if series.empty:
+        return None
+    return float(series.mean())
+
+
+def write_comparison(
+    results_folder: str,
+    ranked: List[Dict[str, Any]],
+    version: str,
+    metric: str = RANKING_METRIC,
+) -> str:
+    """Write the chunking comparison JSON report to `results_folder`.
+
+    Args:
+        results_folder: Folder to write ``chunking_comparison.json`` into.
+        ranked: Ranked strategy dicts as returned by :func:`rank_strategies`.
+        version: Package version to stamp into the report.
+        metric: The ranking metric name to record.
+
+    Returns:
+        The path to the written JSON file.
+    """
+    best = next((e["name"] for e in ranked if e.get("score") is not None), None)
+    report = {
+        "version": version,
+        "generated_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "ranking_metric": metric,
+        "best_strategy": best,
+        "strategies": [
+            {
+                "name": e["name"],
+                "chunk_size": e.get("chunk_size"),
+                "chunk_overlap": e.get("chunk_overlap"),
+                "score": e.get("score"),
+                "results_file": e.get("results_file"),
+            }
+            for e in ranked
+        ],
+    }
+    json_path = os.path.join(results_folder, COMPARISON_JSON_FILENAME)
+    with open(json_path, "w", encoding="utf-8") as f:
+        json.dump(report, f, indent=2)
+    return json_path
+
+
+def print_summary(ranked: List[Dict[str, Any]], metric: str = RANKING_METRIC) -> None:
+    """Print a ranked table of chunking strategies and the winner to stdout."""
+    print(f"\n=== Chunking Strategy Comparison (ranked by {metric}) ===")
+    print(f"{'Rank':<5} {'Strategy':<16} {'size/overlap':<14} {'Score':<8}")
+    for rank, e in enumerate(ranked, start=1):
+        score = e.get("score")
+        score_str = f"{score:.4f}" if score is not None else "N/A"
+        size_overlap = f"{e.get('chunk_size')}/{e.get('chunk_overlap')}"
+        print(f"{rank:<5} {e['name']:<16} {size_overlap:<14} {score_str:<8}")
+
+    best = next((e for e in ranked if e.get("score") is not None), None)
+    if best:
+        print(f"\n🏆 Best chunking strategy: {best['name']} "
+              f"(chunk_size={best.get('chunk_size')}, "
+              f"chunk_overlap={best.get('chunk_overlap')}, "
+              f"{metric}={best['score']:.4f})")
+    else:
+        print("\nNo chunking strategy could be scored.")
+    print("=" * 60 + "\n")

--- a/open_rag_eval/connectors/connector.py
+++ b/open_rag_eval/connectors/connector.py
@@ -9,6 +9,21 @@ from tqdm import tqdm
 logger = logging.getLogger(__name__)
 
 
+def _sanitize_row(row):
+    """Strip NUL bytes from string values in a result row.
+
+    Extracted document text (e.g. from PDFs) can contain NUL (``\\x00``)
+    characters. On Python 3.10 the stdlib ``csv`` writer raises
+    "need to escape, but no escapechar set" when a field contains a NUL,
+    and even where it doesn't, NUL bytes break ``pandas.read_csv``. NUL is
+    not meaningful text, so we drop it before writing.
+    """
+    return {
+        key: value.replace("\x00", "") if isinstance(value, str) else value
+        for key, value in row.items()
+    }
+
+
 class Connector(ABC):
 
     def __init__(self,
@@ -53,7 +68,7 @@ class Connector(ABC):
                         results = self.process_query(query, run_idx + 1)
                         if results:
                             for row in results:
-                                writer.writerow(row)
+                                writer.writerow(_sanitize_row(row))
         else:
             # Create repeated queries based on self.repeat_query
             repeated_queries = [(query, run_idx + 1)
@@ -83,7 +98,7 @@ class Connector(ABC):
                 writer.writeheader()
                 results_buffer.sort(key=lambda x: x[0])
                 for _, row in results_buffer:
-                    writer.writerow(row)
+                    writer.writerow(_sanitize_row(row))
 
         logger.info("%s query processing is complete. Results saved to %s",
                     self.get_connector_name(), output_path)

--- a/open_rag_eval/connectors/langchain_connector.py
+++ b/open_rag_eval/connectors/langchain_connector.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from typing import Optional
 
 from langchain_community.document_loaders import DirectoryLoader
 from langchain_text_splitters import RecursiveCharacterTextSplitter
@@ -9,6 +10,7 @@ from langchain_core.output_parsers import StrOutputParser
 from langchain_core.runnables import RunnablePassthrough
 from langchain_core.prompts import ChatPromptTemplate
 
+from open_rag_eval.chunking import ChunkingStrategy
 from open_rag_eval.connectors.connector import Connector
 from open_rag_eval.utils.constants import API_ERROR
 
@@ -24,6 +26,8 @@ class LangChainConnector(Connector):
             top_k: int = 10,
             max_workers: int = -1,
             repeat_query: int = 1,  # Add repeat_query parameter
+            chunking_strategy: Optional[ChunkingStrategy] = None,
+            output_filename: Optional[str] = None,
     ) -> None:
         self.top_k = top_k
 
@@ -31,7 +35,9 @@ class LangChainConnector(Connector):
         queries_csv = config.get("input_queries", "")
         results_folder = config.get("results_folder",
                                     ".")  # Default to current directory
-        generated_answers_filename = config.get(
+        # When the chunking-comparison layer drives this connector, it routes
+        # each strategy to its own answers file via output_filename.
+        generated_answers_filename = output_filename or config.get(
             "generated_answers", "langchain_generated_answers.csv")
         outputs_csv = os.path.join(results_folder, generated_answers_filename)
 
@@ -47,8 +53,16 @@ class LangChainConnector(Connector):
         loader = DirectoryLoader(folder, glob="**/*.*")
         docs = loader.load()
 
-        text_splitter = RecursiveCharacterTextSplitter(chunk_size=1000,
-                                                       chunk_overlap=200)
+        # Build the text splitter from the chunking strategy. Defaults preserve
+        # the previous hardcoded behavior (chunk_size=1000, chunk_overlap=200).
+        chunk_size = chunking_strategy.chunk_size if chunking_strategy else 1000
+        chunk_overlap = chunking_strategy.chunk_overlap if chunking_strategy else 200
+        if chunking_strategy:
+            logger.info(
+                "Using chunking strategy '%s' (chunk_size=%d, chunk_overlap=%d).",
+                chunking_strategy.name, chunk_size, chunk_overlap)
+        text_splitter = RecursiveCharacterTextSplitter(chunk_size=chunk_size,
+                                                       chunk_overlap=chunk_overlap)
         splits = text_splitter.split_documents(docs)
         vectorstore = Chroma.from_documents(documents=splits,
                                             embedding=OpenAIEmbeddings())

--- a/open_rag_eval/connectors/llama_index_connector.py
+++ b/open_rag_eval/connectors/llama_index_connector.py
@@ -1,12 +1,15 @@
 import logging
 import os
+from typing import Optional
 
 from llama_index.core import VectorStoreIndex, SimpleDirectoryReader, Settings
 from llama_index.core.base.base_query_engine import BaseQueryEngine
+from llama_index.core.node_parser import SentenceSplitter
 from llama_index.core.query_engine.citation_query_engine import CitationQueryEngine
 from llama_index.embeddings.openai import OpenAIEmbedding
 from llama_index.llms.openai import OpenAI
 
+from open_rag_eval.chunking import ChunkingStrategy
 from open_rag_eval.connectors.connector import Connector
 from open_rag_eval.utils.constants import NO_ANSWER, API_ERROR
 
@@ -24,12 +27,29 @@ class LlamaIndexConnector(Connector):
             openai_llm_model: str = "gpt-4.1-mini",
             max_workers: int = -1,
             repeat_query: int = 1,  # Add repeat_query parameter
+            chunking_strategy: Optional[ChunkingStrategy] = None,
+            output_filename: Optional[str] = None,
     ) -> BaseQueryEngine:
         Settings.embed_model = OpenAIEmbedding(model=openai_embedding_model)
         Settings.llm = OpenAI(model=openai_llm_model, temperature=0.0)
 
         documents = SimpleDirectoryReader(folder).load_data()
-        index = VectorStoreIndex.from_documents(documents)
+
+        # Build the index, applying the chunking strategy as a node parser when
+        # provided. Without a strategy, LlamaIndex's default node parsing is used.
+        if chunking_strategy:
+            logger.info(
+                "Using chunking strategy '%s' (chunk_size=%d, chunk_overlap=%d).",
+                chunking_strategy.name, chunking_strategy.chunk_size,
+                chunking_strategy.chunk_overlap)
+            node_parser = SentenceSplitter(
+                chunk_size=chunking_strategy.chunk_size,
+                chunk_overlap=chunking_strategy.chunk_overlap,
+            )
+            index = VectorStoreIndex.from_documents(
+                documents, transformations=[node_parser])
+        else:
+            index = VectorStoreIndex.from_documents(documents)
         retriever = index.as_retriever(similarity_top_k=top_k)
         self.top_k = top_k
         self.query_engine = CitationQueryEngine.from_args(
@@ -42,7 +62,9 @@ class LlamaIndexConnector(Connector):
         queries_csv = config.get("input_queries", "")
         results_folder = config.get("results_folder",
                                     ".")  # Default to current directory
-        generated_answers_filename = config.get(
+        # When the chunking-comparison layer drives this connector, it routes
+        # each strategy to its own answers file via output_filename.
+        generated_answers_filename = output_filename or config.get(
             "generated_answers", "llamaindex_generated_answers.csv")
         outputs_csv = os.path.join(results_folder, generated_answers_filename)
 

--- a/open_rag_eval/run_eval.py
+++ b/open_rag_eval/run_eval.py
@@ -2,13 +2,14 @@
 This script evaluates the performance of a retrieval-augmented generation (RAG) system.
 """
 
+import inspect
 import json
 import logging
 import os
 import shutil
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import pandas as pd
 from omegaconf import DictConfig, ListConfig, OmegaConf
@@ -16,6 +17,8 @@ from pandas.errors import EmptyDataError
 
 from open_rag_eval import connectors, evaluators, models
 from open_rag_eval._version import __version__
+from open_rag_eval.chunking import ChunkingStrategy, parse_chunking_strategies
+from open_rag_eval import chunking_comparison
 from open_rag_eval.rag_results_loader import RAGResultsLoader
 from open_rag_eval.utils.constants import CONSISTENCY, CONSISTENCYEVALUATOR
 
@@ -101,12 +104,20 @@ def get_evaluator(evaluator_config: Dict[str, Any]) -> evaluators.Evaluator:
         raise ImportError(f"Could not load evaluator {evaluator_type}: {str(e)}") from e
 
 
-def get_connector(config: Dict[str, Any]) -> connectors.Connector:
+def get_connector(
+    config: Dict[str, Any],
+    chunking_strategy: Optional[ChunkingStrategy] = None,
+    output_filename: Optional[str] = None,
+) -> connectors.Connector:
     """
     Dynamically import and instantiate a connector class based on configuration.
 
     Args:
         config: Configuration dictionary containing connector settings
+        chunking_strategy: Optional chunking strategy to apply. Only forwarded to
+            connectors whose constructor accepts a ``chunking_strategy`` argument.
+        output_filename: Optional override for the generated-answers filename.
+            Only forwarded to connectors that accept an ``output_filename`` argument.
 
     Returns:
         An instance of the specified connector
@@ -116,10 +127,31 @@ def get_connector(config: Dict[str, Any]) -> connectors.Connector:
     connector_type = config.connector.type
     try:
         connector_class = getattr(connectors, connector_type)
-        return connector_class(config, **config.connector.options)
+
+        # Only forward chunking-related kwargs to connectors that support them,
+        # keeping connectors like VectaraConnector untouched.
+        params = inspect.signature(connector_class.__init__).parameters
+        extra = {}
+        if chunking_strategy is not None and "chunking_strategy" in params:
+            extra["chunking_strategy"] = chunking_strategy
+        if output_filename is not None and "output_filename" in params:
+            extra["output_filename"] = output_filename
+
+        return connector_class(config, **config.connector.options, **extra)
 
     except (ImportError, AttributeError) as e:
         raise ImportError(f"Could not load connector {connector_type}: {str(e)}") from e
+
+
+def _connector_supports_chunking(config: Dict[str, Any]) -> bool:
+    """Return True if the configured connector accepts a chunking_strategy."""
+    if "connector" not in config:
+        return False
+    try:
+        connector_class = getattr(connectors, config.connector.type)
+    except AttributeError:
+        return False
+    return "chunking_strategy" in inspect.signature(connector_class.__init__).parameters
 
 
 def merge_eval_results(results_folder, config, per_evaluator_columns=None):
@@ -361,48 +393,26 @@ def _print_token_usage_summary(results, evaluator_type: str):
         print("=" * 50 + "\n")
 
 
-def run_eval(config_path: str):
-    """
-    Main function to run the evaluation process.
+def _run_evaluators(config, results_folder, rag_results, file_suffix="", plot=True):
+    """Run all configured evaluators over `rag_results` and write per-evaluator CSVs.
+
     Args:
-        config_path: Path to the configuration file
+        config: Loaded evaluation config.
+        results_folder: Folder to write evaluator CSVs and plots into.
+        rag_results: List of MultiRAGResult to evaluate.
+        file_suffix: String inserted before the eval_results_file name, used by
+            the chunking-comparison layer to tag per-strategy output files
+            (e.g. "small-" -> "TRECEvaluator-small-results.csv"). Empty by default
+            for the standard single-pass behavior.
+        plot: When True, write per-evaluator metric plots.
+
+    Returns:
+        A tuple (per_evaluator_columns, results_paths) where per_evaluator_columns
+        maps evaluator type -> consolidated column list (for merging) and
+        results_paths maps evaluator type -> path of its written results CSV.
     """
-    # Load configuration
-    if not Path(config_path).exists():
-        raise FileNotFoundError(f"Config file not found: {config_path}")
-
-    config = OmegaConf.load(config_path)
-
-    # Create output folder.
-    results_folder = config.results_folder
-    if os.path.exists(results_folder):
-        print(f"WARNING: Output folder {results_folder} already exists...")
-    os.makedirs(results_folder, exist_ok=True)
-
-    # Copy the config file from config_path to the output folder.
-    config_file_name = os.path.basename(config_path)
-    shutil.copy2(config_path, os.path.join(results_folder, config_file_name))
-
-    # If connector configured - run it to generate results (or read results)
-    connector = get_connector(config)
-    if connector:
-        connector.fetch_data()
-
-    # Load queries with expected_answer (golden answers) if available
-    queries_df = None
-    if hasattr(config, 'input_queries') and config.input_queries:
-        queries_path = config.input_queries
-        if os.path.exists(queries_path):
-            queries_df = pd.read_csv(queries_path)
-            if 'expected_answer' in queries_df.columns:
-                num_golden = queries_df['expected_answer'].notna().sum()
-                print(f"Loaded {num_golden} golden answers from {queries_path}")
-
-    answer_path = os.path.join(results_folder, config.generated_answers)
-    rag_results = RAGResultsLoader(answer_path, queries_df=queries_df).load()
-
-    # Run evaluation
     per_evaluator_columns = {}
+    results_paths = {}
     precomputed_metric_scores_by_query = {}
 
     # Normalize to list
@@ -447,9 +457,10 @@ def run_eval(config_path: str):
 
         # Save results
         eval_results_path = os.path.join(
-            results_folder, f"{evaluator_type}-{config.eval_results_file}"
+            results_folder, f"{evaluator_type}-{file_suffix}{config.eval_results_file}"
         )
         evaluator.to_csv(results, eval_results_path)
+        results_paths[evaluator_type] = eval_results_path
 
         # Print token usage summary
         _print_token_usage_summary(results, evaluator_type)
@@ -462,22 +473,158 @@ def run_eval(config_path: str):
                 continue
 
             per_evaluator_columns[evaluator_type] = evaluator.get_consolidated_columns()
-            evaluator.plot_metrics(
-                csv_files=[eval_results_path],
-                output_file=os.path.join(
-                    results_folder, f"{evaluator_type}-{config.metrics_file}"
-                ),
-                metrics_to_plot=evaluator.get_metrics_to_plot(),
-            )
-            print(
-                f"Graph saved to {os.path.join(results_folder, f'{evaluator_type}-{config.metrics_file}')}"
-            )
+            if plot:
+                metrics_plot_path = os.path.join(
+                    results_folder, f"{evaluator_type}-{file_suffix}{config.metrics_file}"
+                )
+                evaluator.plot_metrics(
+                    csv_files=[eval_results_path],
+                    output_file=metrics_plot_path,
+                    metrics_to_plot=evaluator.get_metrics_to_plot(),
+                )
+                print(f"Graph saved to {metrics_plot_path}")
         except (FileNotFoundError, EmptyDataError):
             logging.warning(f"Skipping plot: {eval_results_path} not found or empty.")
         except Exception as e:
             logging.exception(
                 f"Failed to read or plot metrics from {eval_results_path}: {str(e)}"
             )
+
+    return per_evaluator_columns, results_paths
+
+
+def _load_queries_df(config):
+    """Load the queries CSV (with optional golden answers), or None if absent."""
+    if hasattr(config, 'input_queries') and config.input_queries:
+        queries_path = config.input_queries
+        if os.path.exists(queries_path):
+            queries_df = pd.read_csv(queries_path)
+            if 'expected_answer' in queries_df.columns:
+                num_golden = queries_df['expected_answer'].notna().sum()
+                print(f"Loaded {num_golden} golden answers from {queries_path}")
+            return queries_df
+    return None
+
+
+def _run_chunking_comparison(config, results_folder, queries_df):
+    """Run the pipeline once per chunking strategy and report the best one.
+
+    For each strategy, the connector re-indexes the documents with that strategy
+    and writes a strategy-tagged answers CSV; evaluators then produce
+    strategy-tagged result CSVs. Strategies are ranked by mean UMBRELA retrieval
+    score, and a comparison plot + JSON report + console summary are emitted.
+    """
+    strategies = parse_chunking_strategies(config.chunking)
+    print(f"Comparing {len(strategies)} chunking strategies: "
+          f"{', '.join(s.name for s in strategies)}")
+
+    strategy_results = []
+    trec_csvs = {}
+    for strategy in strategies:
+        print(f"\n--- Chunking strategy: {strategy.name} "
+              f"(chunk_size={strategy.chunk_size}, chunk_overlap={strategy.chunk_overlap}) ---")
+        answers_filename = f"answers_{strategy.name}.csv"
+
+        # Re-index and generate answers for this strategy.
+        connector = get_connector(
+            config, chunking_strategy=strategy, output_filename=answers_filename
+        )
+        connector.fetch_data()
+
+        answer_path = os.path.join(results_folder, answers_filename)
+        rag_results = RAGResultsLoader(answer_path, queries_df=queries_df).load()
+
+        # Evaluate this strategy; skip per-strategy plots to reduce clutter.
+        _, results_paths = _run_evaluators(
+            config, results_folder, rag_results,
+            file_suffix=f"{strategy.name}-", plot=False,
+        )
+
+        trec_path = results_paths.get("TRECEvaluator")
+        strategy_results.append({
+            "name": strategy.name,
+            "chunk_size": strategy.chunk_size,
+            "chunk_overlap": strategy.chunk_overlap,
+            "results_file": trec_path,
+        })
+        if trec_path:
+            trec_csvs[strategy.name] = trec_path
+
+    # Rank strategies and emit comparison artifacts.
+    ranked = chunking_comparison.rank_strategies(strategy_results)
+    chunking_comparison.print_summary(ranked)
+    json_path = chunking_comparison.write_comparison(results_folder, ranked, __version__)
+    print(f"Chunking comparison report saved to {json_path}")
+
+    # Comparison plot: reuse the TREC grouped-boxplot path with one CSV per strategy.
+    if len(trec_csvs) >= 1:
+        try:
+            plot_path = os.path.join(
+                results_folder, chunking_comparison.COMPARISON_PLOT_FILENAME
+            )
+            evaluators.TRECEvaluator.plot_metrics(
+                csv_files=[trec_csvs[s["name"]] for s in ranked if s["name"] in trec_csvs],
+                output_file=plot_path,
+                metrics_to_plot=[
+                    chunking_comparison.RANKING_METRIC,
+                    "generation_score_vital_nuggetizer_score",
+                ],
+            )
+            print(f"Chunking comparison plot saved to {plot_path}")
+        except Exception as e:
+            logging.exception(f"Failed to plot chunking comparison: {str(e)}")
+
+
+def run_eval(config_path: str):
+    """
+    Main function to run the evaluation process.
+    Args:
+        config_path: Path to the configuration file
+    """
+    # Load configuration
+    if not Path(config_path).exists():
+        raise FileNotFoundError(f"Config file not found: {config_path}")
+
+    config = OmegaConf.load(config_path)
+
+    # Create output folder.
+    results_folder = config.results_folder
+    if os.path.exists(results_folder):
+        print(f"WARNING: Output folder {results_folder} already exists...")
+    os.makedirs(results_folder, exist_ok=True)
+
+    # Copy the config file from config_path to the output folder.
+    config_file_name = os.path.basename(config_path)
+    shutil.copy2(config_path, os.path.join(results_folder, config_file_name))
+
+    # Load queries with expected_answer (golden answers) if available
+    queries_df = _load_queries_df(config)
+
+    # Chunking-comparison mode: run the pipeline once per chunking strategy and
+    # report the best one. Only supported for connectors that control document
+    # chunking (LangChain, LlamaIndex).
+    if "chunking" in config and config.chunking:
+        if _connector_supports_chunking(config):
+            _run_chunking_comparison(config, results_folder, queries_df)
+            return
+        logging.warning(
+            "A 'chunking' block was configured but the connector does not support "
+            "chunking strategies. Running a single standard evaluation instead."
+        )
+
+    # Standard single-pass evaluation.
+    # If connector configured - run it to generate results (or read results)
+    connector = get_connector(config)
+    if connector:
+        connector.fetch_data()
+
+    answer_path = os.path.join(results_folder, config.generated_answers)
+    rag_results = RAGResultsLoader(answer_path, queries_df=queries_df).load()
+
+    # Run evaluation
+    per_evaluator_columns, _ = _run_evaluators(
+        config, results_folder, rag_results
+    )
 
     # Merge results from all evaluators into a single CSV file
     merge_eval_results(

--- a/tests/test_chunking_comparison.py
+++ b/tests/test_chunking_comparison.py
@@ -1,0 +1,96 @@
+import json
+import os
+import tempfile
+import unittest
+
+import pandas as pd
+
+from open_rag_eval import chunking_comparison
+from open_rag_eval.chunking_comparison import (
+    RANKING_METRIC,
+    rank_strategies,
+    write_comparison,
+)
+
+
+class TestChunkingComparison(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+
+    def _write_trec_csv(self, name, scores):
+        """Write a minimal TREC-style results CSV with the ranking metric column."""
+        path = os.path.join(self.tmp, f"TRECEvaluator-{name}-results.csv")
+        pd.DataFrame({
+            "query_id": [f"q{i}" for i in range(len(scores))],
+            RANKING_METRIC: scores,
+        }).to_csv(path, index=False)
+        return path
+
+    def test_rank_strategies_orders_by_mean(self):
+        strategy_results = [
+            {"name": "small", "chunk_size": 256, "chunk_overlap": 32,
+             "results_file": self._write_trec_csv("small", [0.2, 0.4])},   # mean 0.3
+            {"name": "medium", "chunk_size": 512, "chunk_overlap": 64,
+             "results_file": self._write_trec_csv("medium", [0.8, 0.6])},  # mean 0.7
+            {"name": "large", "chunk_size": 1024, "chunk_overlap": 128,
+             "results_file": self._write_trec_csv("large", [0.5, 0.5])},   # mean 0.5
+        ]
+        ranked = rank_strategies(strategy_results)
+        self.assertEqual([r["name"] for r in ranked], ["medium", "large", "small"])
+        self.assertAlmostEqual(ranked[0]["score"], 0.7)
+        self.assertAlmostEqual(ranked[2]["score"], 0.3)
+
+    def test_missing_file_scores_none_and_sorts_last(self):
+        strategy_results = [
+            {"name": "good", "chunk_size": 512, "chunk_overlap": 64,
+             "results_file": self._write_trec_csv("good", [0.9])},
+            {"name": "missing", "chunk_size": 256, "chunk_overlap": 32,
+             "results_file": os.path.join(self.tmp, "does-not-exist.csv")},
+        ]
+        ranked = rank_strategies(strategy_results)
+        self.assertEqual(ranked[0]["name"], "good")
+        self.assertEqual(ranked[1]["name"], "missing")
+        self.assertIsNone(ranked[1]["score"])
+
+    def test_missing_metric_column_scores_none(self):
+        path = os.path.join(self.tmp, "no-metric.csv")
+        pd.DataFrame({"query_id": ["q0"], "some_other_col": [1.0]}).to_csv(path, index=False)
+        ranked = rank_strategies([
+            {"name": "x", "chunk_size": 256, "chunk_overlap": 32, "results_file": path}
+        ])
+        self.assertIsNone(ranked[0]["score"])
+
+    def test_write_comparison_outputs_valid_json(self):
+        strategy_results = [
+            {"name": "small", "chunk_size": 256, "chunk_overlap": 32,
+             "results_file": self._write_trec_csv("small", [0.2])},
+            {"name": "big", "chunk_size": 1024, "chunk_overlap": 128,
+             "results_file": self._write_trec_csv("big", [0.9])},
+        ]
+        ranked = rank_strategies(strategy_results)
+        json_path = write_comparison(self.tmp, ranked, version="9.9.9")
+
+        self.assertTrue(os.path.exists(json_path))
+        with open(json_path, encoding="utf-8") as f:
+            report = json.load(f)
+
+        self.assertEqual(report["version"], "9.9.9")
+        self.assertEqual(report["ranking_metric"], RANKING_METRIC)
+        self.assertEqual(report["best_strategy"], "big")
+        self.assertEqual(len(report["strategies"]), 2)
+        self.assertEqual(report["strategies"][0]["name"], "big")
+        self.assertEqual(report["strategies"][0]["chunk_size"], 1024)
+
+    def test_write_comparison_best_is_none_when_unscored(self):
+        ranked = rank_strategies([
+            {"name": "missing", "chunk_size": 256, "chunk_overlap": 32,
+             "results_file": os.path.join(self.tmp, "nope.csv")}
+        ])
+        json_path = write_comparison(self.tmp, ranked, version="1.0.0")
+        with open(json_path, encoding="utf-8") as f:
+            report = json.load(f)
+        self.assertIsNone(report["best_strategy"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_chunking_comparison.py
+++ b/tests/test_chunking_comparison.py
@@ -52,6 +52,19 @@ class TestChunkingComparison(unittest.TestCase):
         self.assertEqual(ranked[1]["name"], "missing")
         self.assertIsNone(ranked[1]["score"])
 
+    def test_run_prefixed_metric_column_is_resolved(self):
+        # TRECEvaluator.to_csv writes the metric prefixed with "run_1_"; ranking
+        # must resolve it the same way TRECEvaluator.plot_metrics does.
+        path = os.path.join(self.tmp, "run-prefixed.csv")
+        pd.DataFrame({
+            "query_id": ["q0", "q1"],
+            f"run_1_{RANKING_METRIC}": [1.2, 1.4],
+        }).to_csv(path, index=False)
+        ranked = rank_strategies([
+            {"name": "x", "chunk_size": 512, "chunk_overlap": 64, "results_file": path}
+        ])
+        self.assertAlmostEqual(ranked[0]["score"], 1.3)
+
     def test_missing_metric_column_scores_none(self):
         path = os.path.join(self.tmp, "no-metric.csv")
         pd.DataFrame({"query_id": ["q0"], "some_other_col": [1.0]}).to_csv(path, index=False)

--- a/tests/test_chunking_strategy.py
+++ b/tests/test_chunking_strategy.py
@@ -1,0 +1,75 @@
+import unittest
+
+from omegaconf import OmegaConf
+
+from open_rag_eval.chunking import ChunkingStrategy, parse_chunking_strategies
+
+
+class TestChunkingStrategy(unittest.TestCase):
+    def test_parse_basic_strategies(self):
+        cfg = OmegaConf.create({
+            "strategies": [
+                {"name": "small", "chunk_size": 256, "chunk_overlap": 32},
+                {"name": "large", "chunk_size": 1024, "chunk_overlap": 128},
+            ]
+        })
+        strategies = parse_chunking_strategies(cfg)
+        self.assertEqual(len(strategies), 2)
+        self.assertIsInstance(strategies[0], ChunkingStrategy)
+        self.assertEqual(strategies[0].name, "small")
+        self.assertEqual(strategies[0].chunk_size, 256)
+        self.assertEqual(strategies[0].chunk_overlap, 32)
+        self.assertEqual(strategies[0].splitter, "recursive")
+        self.assertEqual(strategies[1].name, "large")
+
+    def test_parse_plain_dict(self):
+        cfg = {"strategies": [{"name": "a", "chunk_size": 100, "chunk_overlap": 10}]}
+        strategies = parse_chunking_strategies(cfg)
+        self.assertEqual(len(strategies), 1)
+        self.assertEqual(strategies[0].name, "a")
+
+    def test_defaults_applied(self):
+        cfg = {"strategies": [{"name": "defaulted"}]}
+        strategies = parse_chunking_strategies(cfg)
+        self.assertEqual(strategies[0].chunk_size, 1000)
+        self.assertEqual(strategies[0].chunk_overlap, 200)
+
+    def test_empty_strategies_raises(self):
+        with self.assertRaises(ValueError):
+            parse_chunking_strategies({"strategies": []})
+
+    def test_missing_strategies_raises(self):
+        with self.assertRaises(ValueError):
+            parse_chunking_strategies({})
+
+    def test_none_config_raises(self):
+        with self.assertRaises(ValueError):
+            parse_chunking_strategies(None)
+
+    def test_missing_name_raises(self):
+        with self.assertRaises(ValueError):
+            parse_chunking_strategies({"strategies": [{"chunk_size": 100}]})
+
+    def test_duplicate_name_raises(self):
+        cfg = {"strategies": [{"name": "dup"}, {"name": "dup"}]}
+        with self.assertRaises(ValueError):
+            parse_chunking_strategies(cfg)
+
+    def test_overlap_ge_size_raises(self):
+        cfg = {"strategies": [{"name": "bad", "chunk_size": 100, "chunk_overlap": 100}]}
+        with self.assertRaises(ValueError):
+            parse_chunking_strategies(cfg)
+
+    def test_non_positive_size_raises(self):
+        cfg = {"strategies": [{"name": "bad", "chunk_size": 0, "chunk_overlap": 0}]}
+        with self.assertRaises(ValueError):
+            parse_chunking_strategies(cfg)
+
+    def test_negative_overlap_raises(self):
+        cfg = {"strategies": [{"name": "bad", "chunk_size": 100, "chunk_overlap": -5}]}
+        with self.assertRaises(ValueError):
+            parse_chunking_strategies(cfg)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Summary
Adds an optional middle layer to the evaluation pipeline that compares multiple **document chunking strategies** against one another and reports the best-performing one. Today chunking is hardcoded in the local-document connectors (`LangChainConnector` → `chunk_size=1000, chunk_overlap=200`; `LlamaIndexConnector` → default node parsing), so there's no way to measure how chunk size/overlap affect retrieval and answer quality. This PR makes that a first-class, comparable step.

When an optional `chunking:` block is present in the eval config, the pipeline re-indexes the documents once per strategy, runs the configured evaluators on each, ranks the strategies by **mean UMBRELA retrieval score**, and emits a comparison plot, a JSON report, and ranks the winner.

Fully backward compatible: with no `chunking:` block, the pipeline runs exactly as before.

## How it works
```yaml
connector:
  type: "LangChainConnector"   # or "LlamaIndexConnector"
  options:
    folder: /path/to/docs/
    top_k: 10
chunking:
  strategies:
    - { name: small,  chunk_size: 256,  chunk_overlap: 32 }
    - { name: medium, chunk_size: 512,  chunk_overlap: 64 }
    - { name: large,  chunk_size: 1024, chunk_overlap: 128 }
```

Produces in results_folder/:
- `answers_<name>.csv` and `TRECEvaluator-<name>.json` per strategy
- `chunking_comparison.png` — grouped boxplots, one box per strategy
- `chunking_comparison.json` — ranked strategies with scores
- A ranked summary printed to the console

## Changes

**New**
- `open_rag_eval/chunking/` — library-agnostic ChunkingStrategy descriptor + `parse_chunking_strategies()` (validates unique names, overlap < size, etc.)
- `open_rag_eval/chunking_comparison.py` — `rank_strategies()`, `write_comparison()`, `print_summary()`, ranking logic
- `config_examples/eval_config_chunking_comparison.yaml` — worked example
- Unit tests: `tests/test_chunking_strategy_comparison.py`

**Modified**
- `run_eval.py` — factored the evaluator loop into `_run_evaluators(...)`; added `_run_chunking_comparison(...)`; `get_connector()` now forwards `chunking_strategy` and `output_filename` only to supported connectors
- `langchain_connector.py` / `llama_index_connector.py` — accept an optional `chunking_strategy` and build their splitter/node-parser from it; defaults preserve current behavior exactly
- `README.md` — new "Comparing Chunking Strategies" section

## Scope / Design Notes
- Only applies to connectors that control document chunking (`LangChainConnector`, `LlamaIndexConnector`). Connectors that accept pre-chunked passages log a warning if a `chunking:` block is provided and run a standard single-pass eval.
- "Best" = highest mean `retrieval_score` metric, since chunking primarily affects retrieval quality.
- The comparison plot reuses the existing `TRECEvaluator.plot_metrics()` grouped-boxplot path — no new plotting code.

## Testing
- 17 unit tests for strategy parsing/validation and comparison logic (including a regression test for resolving run-prefixed metric columns)
- Verified end-to-end against a local PDF indexing: per-strategy evaluation, ranking, JSON report, console summary, and comparison plot all produced correctly; large (1024/128) ranked first by both mean UMBRELA and the nugget metric