### PR TITLE
Add unit tests for ROUGE, Citation, and data classes

### DIFF
--- a/tests/test_citation_metric.py
+++ b/tests/test_citation_metric.py
@@ -1,0 +1,107 @@
+"""Unit tests for CitationMetric using a mocked judge (no LLM / API keys)."""
+import unittest
+from unittest.mock import Mock
+
+from open_rag_eval.metrics.citation_metric import (
+    CitationMetric,
+    CitationSupport,
+    CitationSupportValues,
+)
+from open_rag_eval.data_classes.rag_results import (
+    RAGResult,
+    RetrievalResult,
+    AugmentedGenerationResult,
+    GeneratedAnswerPart,
+)
+
+
+def _rag(answer_parts, passages):
+    return RAGResult(
+        retrieval_result=RetrievalResult(query="q", retrieved_passages=passages),
+        generation_result=AugmentedGenerationResult(
+            query="q", generated_answer=answer_parts
+        ),
+    )
+
+
+class TestCitationMetric(unittest.TestCase):
+    def setUp(self):
+        self.model = Mock()
+        self.metric = CitationMetric(self.model)
+
+    def test_full_support_scores(self):
+        self.model.parse.return_value = {
+            "response": CitationSupport(support=CitationSupportValues.FULL),
+            "metadata": {"input_tokens": 10, "output_tokens": 2},
+        }
+        result = _rag(
+            [GeneratedAnswerPart(text="Paris is the capital.", citations=["1"])],
+            {"1": "Paris is the capital of France."},
+        )
+        scores = self.metric.compute(result)
+        self.assertEqual(scores["weighted_precision"], 1.0)
+        self.assertEqual(scores["weighted_recall"], 1.0)
+        self.assertEqual(scores["f1"], 1.0)
+        self.assertEqual(scores["citation_score_1"], 1.0)
+        self.assertEqual(scores["part_score_1"], 1.0)
+        self.assertEqual(scores["token_usage"]["total_tokens"], 12)
+        self.model.parse.assert_called_once()
+
+    def test_partial_and_none_support(self):
+        responses = [
+            {
+                "response": CitationSupport(support=CitationSupportValues.PARTIAL),
+                "metadata": {"input_tokens": 5, "output_tokens": 1},
+            },
+            {
+                "response": CitationSupport(support=CitationSupportValues.NONE),
+                "metadata": {"input_tokens": 5, "output_tokens": 1},
+            },
+        ]
+        self.model.parse.side_effect = responses
+        result = _rag(
+            [
+                GeneratedAnswerPart(
+                    text="Statement one.", citations=["a", "b"]
+                )
+            ],
+            {"a": "partially related", "b": "unrelated"},
+        )
+        scores = self.metric.compute(result)
+        # citation averages: a=0.5, b=0.0 -> precision 0.25
+        self.assertAlmostEqual(scores["citation_score_a"], 0.5)
+        self.assertAlmostEqual(scores["citation_score_b"], 0.0)
+        self.assertAlmostEqual(scores["weighted_precision"], 0.25)
+        self.assertAlmostEqual(scores["part_score_1"], 0.25)
+        self.assertAlmostEqual(scores["weighted_recall"], 0.25)
+        self.assertEqual(scores["token_usage"]["total_tokens"], 12)
+
+    def test_missing_citations_zero_part_score(self):
+        result = _rag(
+            [GeneratedAnswerPart(text="No citations here.", citations=[])],
+            {"1": "unused"},
+        )
+        scores = self.metric.compute(result)
+        self.assertEqual(scores["part_score_1"], 0.0)
+        self.assertEqual(scores["weighted_precision"], 0.0)
+        self.assertEqual(scores["weighted_recall"], 0.0)
+        self.assertEqual(scores["f1"], 0.0)
+        self.model.parse.assert_not_called()
+
+    def test_missing_passage_skipped(self):
+        self.model.parse.return_value = {
+            "response": CitationSupport(support=CitationSupportValues.FULL),
+            "metadata": {"input_tokens": 1, "output_tokens": 1},
+        }
+        result = _rag(
+            [GeneratedAnswerPart(text="Claim.", citations=["missing", "1"])],
+            {"1": "supports claim"},
+        )
+        scores = self.metric.compute(result)
+        self.assertIn("citation_score_1", scores)
+        self.assertNotIn("citation_score_missing", scores)
+        self.assertEqual(self.model.parse.call_count, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_data_classes_and_constants.py
+++ b/tests/test_data_classes_and_constants.py
@@ -1,0 +1,38 @@
+"""Lightweight unit tests for data classes and constants (no external services)."""
+import unittest
+
+from open_rag_eval.utils import constants
+from open_rag_eval.data_classes.rag_results import (
+    MultiRAGResult,
+    RAGResult,
+    RetrievalResult,
+    AugmentedGenerationResult,
+    GeneratedAnswerPart,
+)
+
+
+class TestConstants(unittest.TestCase):
+    def test_metric_name_constants(self):
+        self.assertEqual(constants.ROUGE_SCORE, "rouge_score")
+        self.assertEqual(constants.BERT_SCORE, "bert_score")
+        self.assertEqual(constants.NO_ANSWER, "NO_ANSWER")
+
+
+class TestMultiRAGResult(unittest.TestCase):
+    def test_add_result(self):
+        multi = MultiRAGResult(query="q", query_id="1")
+        self.assertEqual(multi.rag_results, [])
+        rag = RAGResult(
+            retrieval_result=RetrievalResult(query="q", retrieved_passages={}),
+            generation_result=AugmentedGenerationResult(
+                query="q",
+                generated_answer=[GeneratedAnswerPart(text="a", citations=[])],
+            ),
+        )
+        multi.add_result(rag)
+        self.assertEqual(len(multi.rag_results), 1)
+        self.assertIsNone(multi.expected_answer)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_rouge_score_similarity_metric.py
+++ b/tests/test_rouge_score_similarity_metric.py
@@ -1,0 +1,85 @@
+"""Deterministic unit tests for ROUGEScoreSimilarityMetric (no LLM / API keys)."""
+import unittest
+
+from open_rag_eval.metrics.rouge_score_similarity_metric import ROUGEScoreSimilarityMetric
+from open_rag_eval.data_classes.rag_results import (
+    MultiRAGResult,
+    RAGResult,
+    RetrievalResult,
+    AugmentedGenerationResult,
+    GeneratedAnswerPart,
+)
+from open_rag_eval.utils.constants import ROUGE_SCORE
+
+
+def _rag_result(query: str, answer: str) -> RAGResult:
+    return RAGResult(
+        retrieval_result=RetrievalResult(
+            query=query, retrieved_passages={"1": "passage"}
+        ),
+        generation_result=AugmentedGenerationResult(
+            query=query,
+            generated_answer=[GeneratedAnswerPart(text=answer, citations=["1"])],
+        ),
+    )
+
+
+def _multi(answers, query="q", query_id="qid") -> MultiRAGResult:
+    multi = MultiRAGResult(query=query, query_id=query_id)
+    for answer in answers:
+        multi.add_result(_rag_result(query, answer))
+    return multi
+
+
+class TestROUGEScoreSimilarityMetric(unittest.TestCase):
+    def setUp(self):
+        self.metric = ROUGEScoreSimilarityMetric()
+
+    def test_name(self):
+        self.assertEqual(self.metric.name, ROUGE_SCORE)
+
+    def test_too_few_answers_returns_empty(self):
+        # Metric requires more than 2 non-empty answers.
+        self.assertEqual(self.metric.compute(_multi(["a", "b"])), [])
+        self.assertEqual(self.metric.compute(_multi(["only one"])), [])
+
+    def test_identical_answers_high_scores(self):
+        text = "The capital of France is Paris."
+        scores = self.metric.compute(_multi([text, text, text]))
+        # C(3,2) = 3 pairs
+        self.assertEqual(len(scores), 3)
+        for score in scores:
+            self.assertGreater(score, 0.99)
+            self.assertLessEqual(score, 1.0)
+
+    def test_diverse_answers_lower_than_identical(self):
+        identical = self.metric.compute(
+            _multi(
+                [
+                    "The cat sat on the mat.",
+                    "The cat sat on the mat.",
+                    "The cat sat on the mat.",
+                ]
+            )
+        )
+        diverse = self.metric.compute(
+            _multi(
+                [
+                    "The cat sat on the mat.",
+                    "Quantum mechanics is fascinating.",
+                    "Baking bread requires flour and water.",
+                ]
+            )
+        )
+        self.assertEqual(len(identical), 3)
+        self.assertEqual(len(diverse), 3)
+        self.assertGreater(sum(identical) / len(identical), sum(diverse) / len(diverse))
+
+    def test_strips_empty_answers(self):
+        # Two empty + two real -> after strip only 2 remain -> empty result
+        scores = self.metric.compute(_multi(["", "  ", "hello world", "hello world"]))
+        self.assertEqual(scores, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Adds deterministic unit tests for classes that were missing coverage (#49):

- `ROUGEScoreSimilarityMetric` (lexical pairwise similarity; no LLM)
- `CitationMetric` (mocked judge; no API keys)
- basic `MultiRAGResult` / constants checks

## Test plan
- [ ] CI unit tests pass on this PR
- [ ] `pytest tests/test_rouge_score_similarity_metric.py tests/test_citation_metric.py tests/test_data_classes_and_constants.py` passes locally after `pip install -r requirements.txt`
